### PR TITLE
Add script for syncing rc database

### DIFF
--- a/cbioportal/data-jobs/README.md
+++ b/cbioportal/data-jobs/README.md
@@ -1,0 +1,17 @@
+# Data Jobs related to cBioPortal
+
+## Sync rc database with production database
+We use a different database for our rc development branch occasinally when it
+needs a different database version. See also:
+https://github.com/cBioPortal/cbioportal/blob/master/CONTRIBUTING.md#branches-within-cbioportal.
+
+To sync the database run:
+
+```
+kubectl apply -f sync_rc_db.yaml
+```
+Make sure to delete the job again after
+```
+kubectl delete -f sync_rc_db.yaml
+```
+See [sync_rc_db.yaml](./sync_rc_db.yaml) for the script.

--- a/cbioportal/data-jobs/sync_rc_db.yaml
+++ b/cbioportal/data-jobs/sync_rc_db.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cbioportal-sync-rc-database
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: cbioportal-importer
+        name: cbioportal-sync-rc-database
+        image: mysql:5.7
+        command: ["/bin/sh", "-c"]
+        args:
+          - echo "Install curl";
+            apt-get update; apt-get install curl -y;
+            echo "Done installing curl";
+
+            echo Drop and create database ${DB_PUBLIC_RC_PORTAL_DB_NAME};
+            echo DROP DATABASE IF EXISTS ${DB_PUBLIC_RC_PORTAL_DB_NAME} | mysql -h${DB_HOST} -u${DB_USER} -p${DB_PASSWORD};
+            echo CREATE DATABASE ${DB_PUBLIC_RC_PORTAL_DB_NAME} | mysql -h${DB_HOST} -u${DB_USER} -p${DB_PASSWORD};
+
+            echo "Copy public database to rc database";
+            date;
+            mysqldump -h${DB_HOST} -u${DB_USER} -p${DB_PASSWORD} --quick --compress ${DB_PUBLIC_PORTAL_DB_NAME} | mysql  -h${DB_HOST} -u${DB_USER} -p${DB_PASSWORD} ${DB_PUBLIC_RC_PORTAL_DB_NAME};
+            date;
+            echo "Done copying database";
+
+            echo "Apply migration to 2.9.1";
+            curl "https://raw.githubusercontent.com/cBioPortal/cbioportal/rc/db-scripts/src/main/resources/migration.sql" | awk '{if (new_version) {print $0} else if ($0 ~ /##version/ && $0 ~ /2.9.1/) { new_version=1; print $0 } }' | mysql  -h${DB_HOST} -u${DB_USER} -p${DB_PASSWORD} ${DB_PUBLIC_RC_PORTAL_DB_NAME};
+      restartPolicy: Never
+  backoffLimit: 0


### PR DESCRIPTION
Add script to dump public database into rc database. Useful for when rc database version differs from production 

Could turn this into a cronjob if we want. Implemented it now as a one off job. More sophisticated would be to have it sync e.g. once a week and make it migrate to the latest version. Right now it is hardcoded to migrate to 2.9.1

Had to increase some timeouts on AWS RDS to get this to work:

```
innodb_lock_wait_timeout
net_read_timeout
net_write_timeout
slave_net_timeout
```
all updated to `3600`