### PR TITLE
Genome Nexus Changes

### DIFF
--- a/genome-nexus/README.md
+++ b/genome-nexus/README.md
@@ -1,21 +1,22 @@
 # Genome Nexus
+Create a namespace specific to genome nexus:
+```
+kubectl create namespace genome-nexus
+```
+
 Set up mongo database initialized with data from [gn-mongo image](https://hub.docker.com/r/genomenexus/gn-mongo/tags/):
 ```
-helm install --version 4.9.1 --name gn-mongo-v0dot6 --set securityContext.enabled=false,image.repository=genomenexus/gn-mongo,image.tag=v0.6,persistence.size=20Gi stable/mongodb
+helm install --version 4.9.1 --name gn-mongo-v0dot9 --set securityContext.enabled=false,image.repository=genomenexus/gn-mongo,image.tag=v0.9,persistence.size=20Gi stable/mongodb --namespace=genome-nexus
 ```
 Deploy genome nexus app:
 ```
 kubectl apply -f gn_spring_boot.yaml
 ```
-Expose as service (actual domain name binding is handled in [../ingress/README.md](../ingress/README.md):
-```
-kubectl apply -f service.yaml
-```
 
 ## Sentry support
 If you want to enable sentry, you need to provide it as a secret:
 ```
-kubectl create secret generic genome-nexus-sentry-dsn --from-literal=dsn=https://sentry-key
+kubectl create secret generic genome-nexus-sentry-dsn --from-literal=dsn=https://sentry-key --namespace=genome-nexus
 ```
 It is referenced in the spring boot app [here](https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/blob/master/genome-nexus/gn_spring_boot.yaml#L34-L38)
 
@@ -26,8 +27,8 @@ Genome Nexus relies heavily on VEP. One can spin up their own version of VEP GRC
 kubectl apply -f vep/gn_vep.yaml
 ```
 
-It takes quite a while to start (~40m), because it downloads the VEP cache data
-first.
+It takes quite a while to start (~10m), because it downloads the VEP cache data
+from S3 first.
 
 ## Notes
 - alpine docker image doesn't play nice with kubernetes (https://twitter.com/inodb/status/999041628970127360)

--- a/genome-nexus/gn_spring_boot.yaml
+++ b/genome-nexus/gn_spring_boot.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     run: gn-spring-boot
   name: gn-spring-boot
-  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/gn-spring-boot
+  selfLink: /apis/extensions/v1beta1/namespaces/genome-nexus/deployments/gn-spring-boot
 spec:
   replicas: 2
   selector:
@@ -30,20 +30,20 @@ spec:
         - name: SERVER_PORT
           value: "8888"
         - name: MONGODB_URI
-          value: mongodb://gn-mongo-v0dot6-mongodb:27017/annotator?connectTimeoutMS=120000
+          value: mongodb://gn-mongo-v0dot9-mongodb:27017/annotator?connectTimeoutMS=120000
         - name: SENTRY_DSN
           valueFrom: 
             secretKeyRef:
               name: genome-nexus-sentry-dsn
               key: dsn
-        image: genomenexus/gn-spring-boot:v1.0.0-150-gd714450-vep-by-region
+        image: genomenexus/gn-spring-boot:v1.0.0-263-g387164e
         imagePullPolicy: Always
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             "-Dspring.data.mongodb.uri=$(MONGODB_URI)",
             # this is to use VEP running inside K8s. Remove to use
             # grch37.rest.ensembl.org instead
-            "-Dgn_vep.region.url=http://gn-vep/vep/human/region/VARIANT",
+            # "-Dgn_vep.region.url=http://gn-vep/vep/human/region/VARIANT",
             "-jar",
             "/app.war"
         ]
@@ -75,7 +75,7 @@ metadata:
     run: gn-spring-boot
     app: gn-spring-boot
   name: genome-nexus
-  selfLink: /api/v1/namespaces/default/services/genome-nexus
+  selfLink: /api/v1/namespaces/genome-nexus/services/genome-nexus
 spec:
   ports:
   - port: 80

--- a/genome-nexus/vep/gn_vep.yaml
+++ b/genome-nexus/vep/gn_vep.yaml
@@ -47,7 +47,7 @@ spec:
             path: /vep/human/region/7:140453136-140453136:1/T
             port: 8888
           initialDelaySeconds: 30
-          timeoutSeconds: 30
+          timeoutSeconds: 60
           periodSeconds: 30
         name: gn-vep
         ports:

--- a/ingress/ingress.yml
+++ b/ingress/ingress.yml
@@ -22,9 +22,6 @@ metadata:
 spec:
   tls:
   - hosts:
-    - v2.genomenexus.org
-    secretName: genome-nexus-v2-cert
-  - hosts:
     - www.cbioportal.org
     secretName: cbioportal-www-cert
   - hosts:
@@ -52,13 +49,6 @@ spec:
     - legacy.oncokb.org
     secretName: oncokb-cert
   rules:
-  - host: v2.genomenexus.org
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: genome-nexus
-          servicePort: http
   - host: www.cbioportal.org
     http:
       paths:
@@ -157,4 +147,40 @@ spec:
       - path: /
         backend:
           serviceName: kube-prometheus-grafana
+          servicePort: http
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gn-ingress
+  namespace: genome-nexus
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    ingress.kubernetes.io/proxy-connect-timeout: "300"
+    ingress.kubernetes.io/proxy-read-timeout: "300"
+    ingress.kubernetes.io/proxy-send-timeout: "300"
+    # ingress.kubernetes.io/large-client-header-buffers: "4 32k"
+    # increae max response size to avoid 413 errors see
+    # https://github.com/kubernetes/ingress-nginx/issues/1824
+    nginx.ingress.kubernetes.io/proxy-body-size: 512m
+    ingress.kubernetes.io/proxy-body-size: 512m
+    # add proxy protocol to header
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+spec:
+  tls:
+  - hosts:
+    - v2.genomenexus.org
+    secretName: genome-nexus-v2-cert
+  rules:
+  - host: v2.genomenexus.org
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: genome-nexus
           servicePort: http


### PR DESCRIPTION
- Create separate namespace for genome nexus. It is possible there have
been some problems with having two mongo helm charts running
(session-service and genome-nexus). Maybe having these in separate
namespaces will help.
- gn-vep seemed to restart a lot so increase timeouts
- since genome nexus is in a new namespace the ingress had to be updated
as well