### PR TITLE
Modify cache setup to work with latest VEP wrapper

### DIFF
--- a/genome-nexus/vep/gn_vep.yaml
+++ b/genome-nexus/vep/gn_vep.yaml
@@ -30,7 +30,8 @@ spec:
       - env:
         - name: SERVER_PORT
           value: "8888"
-        image: genomenexus/gn-vep:27223ebc69be55f8d6b31b9111c697ff7b2c0850
+        # TODO change image
+        image: mandaewilson/dockerveptest:latest
         imagePullPolicy: Always
         volumeMounts:
         - name: vep-data
@@ -60,13 +61,13 @@ spec:
       # run on genome nexus machines
       nodeSelector:
          kops.k8s.io/instancegroup: genome-nexus
-      # download data from s3 bucket (takes ~6m).
+      # download data from s3 bucket (takes ~15m).
       # TODO: It might be better to create a volume from an existing snapshot.
       initContainers:
       - name: download-vep-cache
         image: busybox:1.30.0
         command: ['sh', '-c',
-            'cd /vep_data; wget https://gn-vep-data.s3.amazonaws.com/file_list.txt; for f in $(cat file_list.txt); do mkdir -p $(dirname $f); wget https://gn-vep-data.s3.amazonaws.com/$f -O $f; done; cd cache; tar xvzf homo_sapiens_vep_92_GRCh37.tar.gz'
+            'cd /vep_data; mkdir -p cache/tmp; chmod a+w cache/tmp; wget https://test-gn-vep-data.s3.amazonaws.com/file_list.txt; for f in $(cat file_list.txt); do mkdir -p $(dirname $f); wget https://test-gn-vep-data.s3.amazonaws.com/$f -O $f; done; cd cache; tar xvf homo_sapiens_vep_98_GRCh37.tar'
         ]
         volumeMounts:
         - name: vep-data


### PR DESCRIPTION
DO NOT MERGE.  We need to modify the docker image name.

Modify the cache setup.
    - Indexed.
    - Version 98 GRCh37.
    - Works with latest VEP wrapper.