### PR TITLE
Do not hard code the java location

### DIFF
--- a/cbioportal/cbioportal_backend_beta.yaml
+++ b/cbioportal/cbioportal_backend_beta.yaml
@@ -25,7 +25,6 @@ spec:
       labels:
         run: cbioportal-backend-beta
     spec:
-    spec:
       volumes:
       - name: cbioportal-frontend-config-volume
         configMap:
@@ -38,7 +37,7 @@ spec:
         volumeMounts:
         - name: cbioportal-frontend-config-volume
           mountPath: /cbioportal/
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             # "-Xms5g",

--- a/cbioportal/cbioportal_backend_genie_archive.yaml
+++ b/cbioportal/cbioportal_backend_genie_archive.yaml
@@ -30,7 +30,7 @@ spec:
         - configMapRef:
             name: cbioportal-genie-archive
         image: cbioportal/cbioportal:3.6.22-redis-web-shenandoah
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             # "-Xms5g",

--- a/cbioportal/cbioportal_backend_genie_private.yaml
+++ b/cbioportal/cbioportal_backend_genie_private.yaml
@@ -54,7 +54,7 @@ spec:
         - name: cbioportal-genie-private-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             # "-Xms5g",

--- a/cbioportal/cbioportal_backend_genie_private_beta.yaml
+++ b/cbioportal/cbioportal_backend_genie_private_beta.yaml
@@ -30,7 +30,7 @@ spec:
         - configMapRef:
             name: cbioportal-genie-private-beta
         image: cbioportal/cbioportal:release-genie-performance-redis-web-shenandoah
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             # "-Xms5g",

--- a/cbioportal/cbioportal_backend_genie_public.yaml
+++ b/cbioportal/cbioportal_backend_genie_public.yaml
@@ -30,7 +30,7 @@ spec:
         - configMapRef:
             name: cbioportal-genie-public
         image: cbioportal/cbioportal:5.1.7-web-shenandoah
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             # "-Xms5g",

--- a/cbioportal/cbioportal_backend_jprofiler_agent.yaml
+++ b/cbioportal/cbioportal_backend_jprofiler_agent.yaml
@@ -45,7 +45,7 @@ spec:
         - name: PORTAL_HOME
           value: /cbioportal/
         image: cbioportal/cbioportal:3.7.19-web-shenandoah 
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/cbioportal/cbioportal_backend_master.yaml
+++ b/cbioportal/cbioportal_backend_master.yaml
@@ -37,7 +37,7 @@ spec:
         volumeMounts:
         - name: cbioportal-frontend-config-volume
           mountPath: /cbioportal/
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             # "-Xms5g",

--- a/cbioportal/cbioportal_backend_rc.yaml
+++ b/cbioportal/cbioportal_backend_rc.yaml
@@ -36,7 +36,7 @@ spec:
         volumeMounts:
         - name: ehcache-volume
           mountPath: /ehcache
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/cbioportal/cbioportal_spring_boot.yaml
+++ b/cbioportal/cbioportal_spring_boot.yaml
@@ -37,7 +37,7 @@ spec:
         volumeMounts:
         - name: cbioportal-frontend-config-volume
           mountPath: /cbioportal/
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/cbioportal/htan/cbioportal_backend_htan.yaml
+++ b/cbioportal/htan/cbioportal_backend_htan.yaml
@@ -58,7 +58,7 @@ spec:
         - name: cbioportal-htan-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/cbioportal/webinar/cbioportal_webinar.yaml
+++ b/cbioportal/webinar/cbioportal_webinar.yaml
@@ -37,7 +37,7 @@ spec:
         volumeMounts:
         - name: ehcache-volume
           mountPath: /ehcache
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-dev/cbioportal-eks-demo-deployment-service.yaml
+++ b/digits-eks/eks-dev/cbioportal-eks-demo-deployment-service.yaml
@@ -54,7 +54,7 @@ spec:
         - name: cbioportal-eks-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-prod/cbioportal-eks-msk-beta-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-msk-beta-deployment-service.yaml
@@ -54,7 +54,7 @@ spec:
         - name: msk-beta-eks-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-prod/cbioportal-eks-msk-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-msk-deployment-service.yaml
@@ -54,7 +54,7 @@ spec:
         - name: msk-eks-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-prod/cbioportal-eks-private-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-private-deployment-service.yaml
@@ -54,7 +54,7 @@ spec:
         - name: private-eks-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-prod/cbioportal-eks-sclc-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-sclc-deployment-service.yaml
@@ -54,7 +54,7 @@ spec:
         - name: sclc-eks-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-prod/cbioportal-eks-triage-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-triage-deployment-service.yaml
@@ -54,7 +54,7 @@ spec:
         - name: triage-eks-configmap-volume
           mountPath: /cbioportal/cbioportal-saml-keystore.jks
           subPath: cbioportal-saml-keystore.jks
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/digits-eks/eks-prod/old/dremio-prototype-deployment-from-public.yaml
+++ b/digits-eks/eks-prod/old/dremio-prototype-deployment-from-public.yaml
@@ -38,7 +38,7 @@ spec:
         #volumeMounts:
         #- name: cbioportal-frontend-config-volume
         #mountPath: /cbioportal/
-        command: [ "/usr/bin/java" ]
+        command: [ "java" ]
         args: [
             # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
             "-Xms100m",

--- a/oncokb/oncokb_curate.yaml
+++ b/oncokb/oncokb_curate.yaml
@@ -34,7 +34,7 @@ spec:
           - configMapRef:
               name: oncokb-curation-platform-credentials
         image: cbioportal/oncokb:0.3.12-curation-test
-        command: ["/usr/bin/java"]
+        command: ["java"]
         args: [
                   # from https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/
                   "-Xms250m",


### PR DESCRIPTION
`/usr/bin/java` is no longer the default java location after switching to eclipse-temurin. We should let the system decides rather.