### PR TITLE
Mount recaptcha credentials secret into oncokb-public

### DIFF
--- a/oncokb/oncokb-prod/oncokb_public.yaml
+++ b/oncokb/oncokb-prod/oncokb_public.yaml
@@ -99,6 +99,16 @@ spec:
           effect: "NoSchedule"
       nodeSelector:
         kops.k8s.io/instancegroup: oncokb
+          volumeMounts:
+          # The subPath is needed so that mounting the secret as a single file doesn't override
+          # the contents of the existing directory. 
+          - mountPath: /app/resources/config/recaptcha/oncokb-recaptcha-credentials.json
+            subPath: oncokb-recaptcha-credentials.json
+            name: recaptcha-credentials
+      volumes:
+      - name: recaptcha-credentials
+        secret:
+          secretName: oncokb-recaptcha-credentials
 
 ---
 apiVersion: v1

--- a/oncokb/oncokb-prod/oncokb_public_beta.yaml
+++ b/oncokb/oncokb-prod/oncokb_public_beta.yaml
@@ -86,6 +86,16 @@ spec:
         effect: "NoSchedule"
       nodeSelector:
         kops.k8s.io/instancegroup: oncokb
+          volumeMounts:
+          # The subPath is needed so that mounting the secret as a single file doesn't override
+          # the contents of the existing directory. 
+          - mountPath: /app/resources/config/recaptcha/oncokb-recaptcha-credentials.json
+            subPath: oncokb-recaptcha-credentials.json
+            name: recaptcha-credentials
+      volumes:
+      - name: recaptcha-credentials
+        secret:
+          secretName: oncokb-recaptcha-credentials
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3371

This commit contains the recaptcha secret https://github.com/knowledgesystems/oncokb-deployment/commit/ec4b49540b946272fd916bf869afcd931f14a08d

The recaptcha specific properties are added in this PR: https://github.com/knowledgesystems/oncokb-deployment/pull/22