### PR TITLE
Deploy genome nexus with temp v0.26 database

### DIFF
--- a/genome-nexus/gn_spring_boot.yaml
+++ b/genome-nexus/gn_spring_boot.yaml
@@ -31,13 +31,13 @@ spec:
         - name: SERVER_PORT
           value: "8888"
         - name: MONGODB_URI
-          value: mongodb://gn-mongo-v0dot25-mongodb:27017/annotator?connectTimeoutMS=120000
+          value: mongodb://gn-mongo-v0dot26-temp-mongodb:27017/annotator?connectTimeoutMS=120000
         - name: SENTRY_DSN
           valueFrom: 
             secretKeyRef:
               name: genome-nexus-sentry-dsn
               key: dsn
-        image: genomenexus/gn-spring-boot:v1.2.3
+        image: genomenexus/gn-spring-boot:v1.2.4
         imagePullPolicy: Always
         command: [ "java" ]
         args: [


### PR DESCRIPTION
We are having a database issue. Creating database with images that contains mutation assessor are always failed. E.g. image tag `0.26_mutationassessor` or `0.25_mutationassessor`. But we were able to create database with `0.25_mutationassessor` smoothly and also have been using `0.25_mutationassessor` on production for a while.
If creating database without mutation assessor, like `0.25` or `0.26` then it works great.
Here is the error message:
```
2023-01-24T21:15:44.006+0000 E STORAGE  [initandlisten] WiredTiger error (-31802) [1674594944:6516][47:0x7f9e2e504080], file:collection-16--6071040969171562533.wt, WT_SESSION.open_cursor: __posix_file_read, 449: /bitnami/mongodb/data/db/collection-16--6071040969171562533.wt: handle-read: pread: failed to read 4096 bytes at offset 4388671488: WT_ERROR: non-specific WiredTiger error Raw: [1674594944:6516][47:0x7f9e2e504080], file:collection-16--6071040969171562533.wt, WT_SESSION.open_cursor: __posix_file_read, 449: /bitnami/mongodb/data/db/collection-16--6071040969171562533.wt: handle-read: pread: failed to read 4096 bytes at offset 4388671488: WT_ERROR: non-specific WiredTiger error
2023-01-24T21:15:44.006+0000 E STORAGE  [initandlisten] Failed to open a WiredTiger cursor: table:collection-16--6071040969171562533
```
Probably related to a disk storage issue that it fails if creating database with importing a large size of data (mutation assessor data is about 4G)

We created a temp database that was based on image `0.26` and dump all mutation assessor data into it. Still need to investigate the cause of failure 