### PR TITLE
Ingress/cert setup for cbiopotal-prod

### DIFF
--- a/public-eks/cbioportal-prod/shared-services/ingress/README.md
+++ b/public-eks/cbioportal-prod/shared-services/ingress/README.md
@@ -1,0 +1,20 @@
+# Attach a domain name to a service
+
+This setup made using the following:
+
+| Dependency    | Version     |
+| ------------- | ----------- |
+| aws-cli       | 2.11.25     |
+| helm          | 2.5.2       |
+| k8s server    | 1.27+       |
+| k8s client    | 1.27+       |
+| ingress-nginx | 4.7.0       |
+| cert-manager  | v1.12.0     |
+
+For ingress to work, subnets must be tagged with the following: 
+
+| Key                             | Value     |
+| ------------------------------- | --------- |
+| kubernetes.io/cluster/<name>    | shared    |
+| kubernetes.io/role/elb          | 1         |
+| kubernetes.io/role/internal-elb | 1         |

--- a/public-eks/cbioportal-prod/shared-services/ingress/cbio-ingress.yml
+++ b/public-eks/cbioportal-prod/shared-services/ingress/cbio-ingress.yml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # add an annotation indicating the issuer to use.
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    ingress.kubernetes.io/proxy-connect-timeout: "300"
+    ingress.kubernetes.io/proxy-read-timeout: "300"
+    ingress.kubernetes.io/proxy-send-timeout: "300"
+    # ingress.kubernetes.io/large-client-header-buffers: "4 32k"
+    # increae max response size to avoid 413 errors see
+    # https://github.com/kubernetes/ingress-nginx/issues/1824
+    nginx.ingress.kubernetes.io/proxy-body-size: 512m
+    ingress.kubernetes.io/proxy-body-size: 512m
+    # add proxy protocol to header
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  name: cbioportal-ingress
+spec:
+  tls:
+  - hosts:
+    - master.cbioportal.org
+    secretName: master-cbio-cert
+  rules:
+  - host: master.cbioportal.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ngnix-service
+            port:
+              number: 80

--- a/public-eks/cbioportal-prod/shared-services/ingress/default_ingress_values.yml
+++ b/public-eks/cbioportal-prod/shared-services/ingress/default_ingress_values.yml
@@ -1,0 +1,35 @@
+controller:
+  config:
+    client-header-buffers: 16k
+    large-client-header-buffers: 4 16k
+    log-format-escape-json: "true"
+    # use output format that can be parsed by fluentd:
+    # https://github.com/kubernetes/ingress-nginx/issues/1664
+    log-format-upstream: '{"proxy_protocol_addr": "$proxy_protocol_addr","remote_addr":
+      "$remote_addr", "proxy_add_x_forwarded_for": "$proxy_add_x_forwarded_for", "remote_user":
+      "$remote_user", "time_local": "$time_local", "request" : "$request", "status":
+      $status, "body_bytes_sent": $body_bytes_sent, "http_referer": "$http_referer",
+      "http_user_agent": "$http_user_agent", "request_length" : $request_length,
+      "request_time" : $request_time, "proxy_upstream_name": "$proxy_upstream_name",
+      "upstream_addr": "$upstream_addr", "upstream_response_length": $upstream_response_length,
+      "upstream_response_time": $upstream_response_time, "upstream_status": $upstream_status}'
+    proxy-body-size: 1024m
+    proxy-buffer-size: 16k
+    proxy-buffers: 16k
+    proxy-connect-timeout: "300"
+    proxy-read-timeout: "300"
+    proxy-send-timeout: "300"
+    use-proxy-protocol: "true"
+  image:
+    tag: 0.27.0
+  metrics:
+    enabled: true
+  replicaCount: 2
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
+      service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  stats:
+    enabled: true
+rbac:
+  create: true

--- a/public-eks/cbioportal-prod/shared-services/ingress/letsencrypt-clusterissuer.yml
+++ b/public-eks/cbioportal-prod/shared-services/ingress/letsencrypt-clusterissuer.yml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # Email address used for ACME registration
+    email: ino@ino.pm
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    disableAccountKeyGeneration: true
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: nginx


### PR DESCRIPTION
YAML files used for Ingress/cert-manager setup in the new cluster. Can replace the original files once migration is fully completed. 