### PR TITLE
Update cbioportal MSK prod svc rolling updates policy

### DIFF
--- a/digits-eks/eks-prod/cbioportal-eks-hgnc-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-hgnc-deployment-service.yaml
@@ -16,8 +16,7 @@ spec:
       run: eks-hgnc
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/digits-eks/eks-prod/cbioportal-eks-msk-beta-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-msk-beta-deployment-service.yaml
@@ -16,8 +16,7 @@ spec:
       run: eks-msk-beta
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:

--- a/digits-eks/eks-prod/cbioportal-eks-msk-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-msk-deployment-service.yaml
@@ -16,7 +16,6 @@ spec:
       run: eks-msk
   strategy:
     rollingUpdate:
-      maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
   template:

--- a/digits-eks/eks-prod/cbioportal-eks-sclc-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-sclc-deployment-service.yaml
@@ -16,7 +16,6 @@ spec:
       run: eks-sclc
   strategy:
     rollingUpdate:
-      maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
   template:

--- a/digits-eks/eks-prod/cbioportal-eks-triage-deployment-service.yaml
+++ b/digits-eks/eks-prod/cbioportal-eks-triage-deployment-service.yaml
@@ -16,7 +16,6 @@ spec:
       run: eks-triage
   strategy:
     rollingUpdate:
-      maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
   template:


### PR DESCRIPTION
When only 1 replica is needed for the service, we should always make sure the maxUnavailable is 0. And maxSurge will not be necessary.