### PR TITLE
Add BTC hackathon example cellxgene datasets.

### DIFF
--- a/public-eks/cbioportal-prod/cellxgene/cellxgene-deployment.yaml
+++ b/public-eks/cbioportal-prod/cellxgene/cellxgene-deployment.yaml
@@ -598,6 +598,380 @@ spec:
           value: "eks-cellxgene"
           effect: "NoSchedule"
 ---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cellxgene-deploy-9
+  labels:
+    app: cellxgene
+    dataset: scrna_MDA_with_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      dataset: scrna_MDA_with_inhibitor_filtered_feature_bc_matrix.h5ad
+  template:
+    metadata:
+      labels:
+        dataset: scrna_MDA_with_inhibitor_filtered_feature_bc_matrix.h5ad
+    spec:
+      containers:
+        - name: cellxgene-app9
+          image: 'edit01/cellxgene:1.2.0'
+          command: ["cellxgene"]
+          args: [
+            "launch",
+            "-p",
+            "8080",
+            "--host",
+            "0.0.0.0",
+            "--backed",
+            "--disable-annotations",
+            "--disable-gene-sets-save",
+            "--gene-sets-file",
+            "/genesets/example_genesets.csv",
+            "s3://jason-test-workspace/btc-gbm/pilot_sharmalab_processed_scrna_MDA_with_inhibitor_filtered_feature_bc_matrix_prepared.h5ad"
+          ]
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          imagePullPolicy: Always
+          # resources:
+          #   limits:
+          #     memory: 7Gi
+          #     cpu: 250m
+          readinessProbe: # Block traffic to container if not ready
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            failureThreshold: 10
+          livenessProbe: # Restart container if not healthy
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 600  # 10min
+            periodSeconds: 3600 # 1hr
+            failureThreshold: 2
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_secret_access_key
+          - name: GENESET_FILE
+            value: https://raw.githubusercontent.com/hweej/single-cell-tools/main/cellxgene/genesets/example_genesets.csv
+      # run on big memory machine
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: eks-cellxgene
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "eks-cellxgene"
+          effect: "NoSchedule"
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cellxgene-deploy-10
+  labels:
+    app: cellxgene
+    dataset: scrna_MDA_without_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      dataset: scrna_MDA_without_inhibitor_filtered_feature_bc_matrix.h5ad
+  template:
+    metadata:
+      labels:
+        dataset: scrna_MDA_without_inhibitor_filtered_feature_bc_matrix.h5ad
+    spec:
+      containers:
+        - name: cellxgene-app10
+          image: 'edit01/cellxgene:1.2.0'
+          command: ["cellxgene"]
+          args: [
+            "launch",
+            "-p",
+            "8080",
+            "--host",
+            "0.0.0.0",
+            "--backed",
+            "--disable-annotations",
+            "--disable-gene-sets-save",
+            "s3://jason-test-workspace/btc-gbm/pilot_sharmalab_processed_scrna_MDA_without_inhibitor_filtered_feature_bc_matrix_prepared.h5ad"
+          ]
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          imagePullPolicy: Always
+          # resources:
+          #   limits:
+          #     memory: 7Gi
+          #     cpu: 250m
+          readinessProbe: # Block traffic to container if not ready
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            failureThreshold: 10
+          livenessProbe: # Restart container if not healthy
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 600  # 10min
+            periodSeconds: 3600 # 1hr
+            failureThreshold: 2
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_secret_access_key
+      # run on big memory machine
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: eks-cellxgene
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "eks-cellxgene"
+          effect: "NoSchedule"
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cellxgene-deploy-11
+  labels:
+    app: cellxgene
+    dataset: scrna_MSK_no_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      dataset: scrna_MSK_no_inhibitor_filtered_feature_bc_matrix.h5ad
+  template:
+    metadata:
+      labels:
+        dataset: scrna_MSK_no_inhibitor_filtered_feature_bc_matrix.h5ad
+    spec:
+      containers:
+        - name: cellxgene-app11
+          image: 'edit01/cellxgene:1.2.0'
+          command: ["cellxgene"]
+          args: [
+            "launch",
+            "-p",
+            "8080",
+            "--host",
+            "0.0.0.0",
+            "--backed",
+            "--disable-annotations",
+            "--disable-gene-sets-save",
+            "s3://jason-test-workspace/btc-gbm/pilot_sharmalab_processed_scrna_MSK_no_inhibitor_filtered_feature_bc_matrix_prepared.h5ad"
+          ]
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          imagePullPolicy: Always
+          # resources:
+          #   limits:
+          #     memory: 7Gi
+          #     cpu: 250m
+          readinessProbe: # Block traffic to container if not ready
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            failureThreshold: 10
+          livenessProbe: # Restart container if not healthy
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 600  # 10min
+            periodSeconds: 3600 # 1hr
+            failureThreshold: 2
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_secret_access_key
+      # run on big memory machine
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: eks-cellxgene
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "eks-cellxgene"
+          effect: "NoSchedule"
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cellxgene-deploy-12
+  labels:
+    app: cellxgene
+    dataset: scrna_MSK_with_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      dataset: scrna_MSK_with_inhibitor_filtered_feature_bc_matrix.h5ad
+  template:
+    metadata:
+      labels:
+        dataset: scrna_MSK_with_inhibitor_filtered_feature_bc_matrix.h5ad
+    spec:
+      containers:
+        - name: cellxgene-app12
+          image: 'edit01/cellxgene:1.2.0'
+          command: ["cellxgene"]
+          args: [
+            "launch",
+            "-p",
+            "8080",
+            "--host",
+            "0.0.0.0",
+            "--backed",
+            "--disable-annotations",
+            "--disable-gene-sets-save",
+            "s3://jason-test-workspace/btc-gbm/pilot_sharmalab_processed_scrna_MSK_with_inhibitor_filtered_feature_bc_matrix_prepared.h5ad"
+          ]
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          imagePullPolicy: Always
+          # resources:
+          #   limits:
+          #     memory: 7Gi
+          #     cpu: 250m
+          readinessProbe: # Block traffic to container if not ready
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            failureThreshold: 10
+          livenessProbe: # Restart container if not healthy
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 600  # 10min
+            periodSeconds: 3600 # 1hr
+            failureThreshold: 2
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_secret_access_key
+      # run on big memory machine
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: eks-cellxgene
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "eks-cellxgene"
+          effect: "NoSchedule"
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cellxgene-deploy-13
+  labels:
+    app: cellxgene
+    dataset: scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix.h5ad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      dataset: scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix.h5ad
+  template:
+    metadata:
+      labels:
+        dataset: scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix.h5ad
+    spec:
+      containers:
+        - name: cellxgene-app13
+          image: 'edit01/cellxgene:1.2.0'
+          command: ["cellxgene"]
+          args: [
+            "launch",
+            "-p",
+            "8080",
+            "--host",
+            "0.0.0.0",
+            "--backed",
+            "--disable-annotations",
+            "--disable-gene-sets-save",
+            "s3://jason-test-workspace/btc-gbm/trial1a_sharma_lab_scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix_prepared.h5ad"
+          ]
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          imagePullPolicy: Always
+          # resources:
+          #   limits:
+          #     memory: 7Gi
+          #     cpu: 250m
+          readinessProbe: # Block traffic to container if not ready
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            failureThreshold: 10
+          livenessProbe: # Restart container if not healthy
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 600  # 10min
+            periodSeconds: 3600 # 1hr
+            failureThreshold: 2
+          env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: cellxgene-creds
+                key: aws_secret_access_key
+      # run on big memory machine
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: eks-cellxgene
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "eks-cellxgene"
+          effect: "NoSchedule"
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -701,3 +1075,69 @@ spec:
     dataset: gbm_filtered_processing2.h5ad
   ports:
     - port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: cellxgene-service-9
+  labels:  # For convenience
+    app: cellxgene
+    dataset: scrna_MDA_with_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  selector:
+    dataset: scrna_MDA_with_inhibitor_filtered_feature_bc_matrix.h5ad
+  ports:
+    - port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: cellxgene-service-10
+  labels:  # For convenience
+    app: cellxgene
+    dataset: scrna_MDA_without_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  selector:
+    dataset: scrna_MDA_without_inhibitor_filtered_feature_bc_matrix.h5ad
+  ports:
+    - port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: cellxgene-service-11
+  labels:  # For convenience
+    app: cellxgene
+    dataset: scrna_MSK_no_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  selector:
+    dataset: scrna_MSK_no_inhibitor_filtered_feature_bc_matrix.h5ad
+  ports:
+    - port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: cellxgene-service-12
+  labels:  # For convenience
+    app: cellxgene
+    dataset: scrna_MSK_with_inhibitor_filtered_feature_bc_matrix.h5ad
+spec:
+  selector:
+    dataset: scrna_MSK_with_inhibitor_filtered_feature_bc_matrix.h5ad
+  ports:
+    - port: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: cellxgene-service-13
+  labels:  # For convenience
+    app: cellxgene
+    dataset: scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix.h5ad
+spec:
+  selector:
+    dataset: scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix.h5ad
+  ports:
+    - port: 8080
+

--- a/public-eks/cbioportal-prod/cellxgene/cellxgene-ingress.yaml
+++ b/public-eks/cbioportal-prod/cellxgene/cellxgene-ingress.yaml
@@ -132,6 +132,41 @@ spec:
                 name: cellxgene-service-8
                 port:
                   number: 8080
+          - path: /pilot_sharmalab_processed_scrna_MDA_with_inhibitor_filtered_feature_bc_matrix_prepared(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cellxgene-service-9
+                port:
+                  number: 8080
+          - path: /pilot_sharmalab_processed_scrna_MDA_without_inhibitor_filtered_feature_bc_matrix_prepared(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cellxgene-service-10
+                port:
+                  number: 8080
+          - path: /pilot_sharmalab_processed_scrna_MSK_no_inhibitor_filtered_feature_bc_matrix_prepared(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cellxgene-service-11
+                port:
+                  number: 8080
+          - path: /pilot_sharmalab_processed_scrna_MSK_with_inhibitor_filtered_feature_bc_matrix_prepared(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cellxgene-service-12
+                port:
+                  number: 8080
+          - path: /trial1a_sharma_lab_scrna_DFCI1_BTC-GBM-001-003-GEX_filtered_feature_bc_matrix_prepared(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cellxgene-service-13
+                port:
+                  number: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Adds 5 additional cellxgene instances to the cbioportal EKS cluster for the purposes of the BTC hackathon