### PR TITLE
Switch public deployment back to `publicdb.cbioportal.org`

### DIFF
--- a/public-eks/cbioportal-prod/cbioportal_spring_boot.yaml
+++ b/public-eks/cbioportal-prod/cbioportal_spring_boot.yaml
@@ -131,7 +131,7 @@ spec:
             "--db.password=$(DB_PASSWORD)",
             "--spring.datasource.driver-class-name=com.mysql.jdbc.Driver",
             "--spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect",
-            "--spring.datasource.url=jdbc:mysql://cbioportal-public-db-blue.caakrwnbyjl6.us-east-1.rds.amazonaws.com:3306/cgds_public_v5?zeroDateTimeBehavior=convertToNull&useSSL=false&allowPublicKeyRetrieval=true",
+            "--spring.datasource.url=jdbc:mysql://publicdb.cbioportal.org:3306/cgds_public_v5?zeroDateTimeBehavior=convertToNull&useSSL=false&allowPublicKeyRetrieval=true",
             "--spring.datasource.username=$(DB_USER)",
             "--spring.datasource.password=$(DB_PASSWORD)",
 #            "-Ddb.connection_string=$(DB_CONNECTION_STRING)",


### PR DESCRIPTION
It seems like the DNS changes (finally) went through-- `master.cbioportal.org`, which references publicdb, is now showing the GDC studies. So it is probably safe to switch `cbioportal.org` back as well.

These changes have not been deployed yet, will do once the PR is merged

/cc @dippindots @inodb @averyniceday 