### PR TITLE
Enable cross-study expression comparison for TCGA GDC studies in public portal

### DIFF
--- a/public-eks/cbioportal-prod/cbioportal_spring_boot.yaml
+++ b/public-eks/cbioportal-prod/cbioportal_spring_boot.yaml
@@ -95,7 +95,7 @@ spec:
             "--java.rmi.server.hostname=localhost",
             # /enable remote debug
             "--frontend.url=https://frontend.cbioportal.org/",
-            "--enable_cross_study_expression=(studies)=>studies.filter(s=>/pan_can_atlas/.test(s.studyId) === false).length === 0",
+            "--enable_cross_study_expression=(studies)=>(studies.filter(s=>/pan_can_atlas/.test(s.studyId) === false).length === 0 || studies.filter(s=>/tcga_gdc/.test(s.studyId) === false).length === 0)",
             "--default_cross_cancer_study_session_id=5c8a7d55e4b046111fee2296",
             "--quick_search.enabled=true",
             "--skin.footer=",


### PR DESCRIPTION
Just porting this change over that is already deployed to the CRDC portal: https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/blob/395ef6c20191c34be83fcc1006f378665690cb29/public-eks/cbioportal-prod/cbioportal_backend_nci.yaml#L107C37-L108C206

Niki wants this feature since the expression data should be normalized enough within TCGA GDC studies. See [related discussion on Slack](https://cbioportal.slack.com/archives/C04PHKPKF2R/p1718890212300399?thread_ts=1718734828.790599&cid=C04PHKPKF2R)

These changes have not been deployed yet, will do once the PR is merged

/cc @dippindots @inodb @averyniceday 