### PR TITLE
Deploy genome nexus beta

### DIFF
--- a/genome-nexus/gn_spring_boot.yaml
+++ b/genome-nexus/gn_spring_boot.yaml
@@ -31,7 +31,7 @@ spec:
         - name: SERVER_PORT
           value: "8888"
         - name: MONGODB_URI
-          value: mongodb://gn-mongo-v0dot31-beta-mongodb:27017/annotator?connectTimeoutMS=120000
+          value: mongodb://gn-mongo-v0dot31-mongodb:27017/annotator?connectTimeoutMS=120000
         - name: SENTRY_DSN
           valueFrom: 
             secretKeyRef:

--- a/genome-nexus/gn_spring_boot_beta.yaml
+++ b/genome-nexus/gn_spring_boot_beta.yaml
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               name: genome-nexus-sentry-dsn
               key: dsn
-        image: genomenexus/gn-spring-boot:1.4.0
+        image: genomenexus/gn-spring-boot:1.4.3
         imagePullPolicy: Always
         command: [ "java" ]
         args: [


### PR DESCRIPTION
Deploy beta instance to gn-spring-boot:1.4.3 with canonical transcript changes
The public instance is deployed with gn-mongo-v0dot31 but the yaml file is not updated before, updating the version to represent the latest deployment. 