### PR TITLE
Add sparky3 connection to airflow

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
@@ -107,6 +107,9 @@ secret:
   - envName: AIRFLOW_CONN_TLLIHPCGPU3_SSH
     secretKey: AIRFLOW_CONN_TLLIHPCGPU3_SSH
     secretName: airflow-gpu3-ssh-uri
+  - envName: AIRFLOW_CONN_PLLIMSKSPARKY3_SSH
+    secretKey: AIRFLOW_CONN_PLLIMSKSPARKY3_SSH
+    secretName: airflow-sparky3-ssh-uri
   - envName: AIRFLOW_VAR_IMPACT_PIPELINE_PASSWORD
     secretKey: AIRFLOW_VAR_IMPACT_PIPELINE_PASSWORD
     secretName: airflow-impact-pipeline-password
@@ -146,6 +149,9 @@ workers:
     - mountPath: /opt/airflow/secrets/gpu3-ssh-keyfile
       name: gpu3-ssh-keyfile
       readOnly: true
+    - mountPath: /opt/airflow/secrets/sparky3-ssh-keyfile
+      name: sparky3-ssh-keyfile
+      readOnly: true
     - mountPath: /opt/airflow/secrets/genie-importer-ssh-keyfile
       name: genie-importer-ssh-keyfile
       readOnly: true
@@ -174,6 +180,9 @@ workers:
     - name: gpu3-ssh-keyfile
       secret:
         secretName: airflow-gpu3-ssh-keyfile
+    - name: sparky3-ssh-keyfile
+      secret:
+        secretName: airflow-sparky3-ssh-keyfile
     - name: genie-importer-ssh-keyfile
       secret:
         secretName: airflow-genie-importer-ssh-keyfile


### PR DESCRIPTION
Set up Airflow connection to sparky3 server for use while hpc3/gpu3 nodes are undergoing RedHat migration.