### PR TITLE
Add Biomni to 666 cbioportal-prod cluster

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/biomni.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/biomni.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: biomni
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/knowledgesystems/knowledgesystems-k8s-deployment
+      path: argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni
+      targetRevision: HEAD
+      directory:
+        recurse: true
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/biomni.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/biomni.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: biomni
+  namespace: argocd
 spec:
   project: default
   sources:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: biomni
+  labels:
+    app: biomni
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: biomni
+  template:
+    metadata:
+      labels:
+        app: biomni
+    spec:
+      containers:
+        - name: biomni
+          image: cbioportal/biomni:latest
+          imagePullPolicy: Always
+          ports:
+            - name: gradio
+              containerPort: 7860
+            - name: mcp
+              containerPort: 8000
+          env:
+            - name: BIOMNI_MODE
+              value: "both"
+            - name: BIOMNI_SKIP_DATA_LAKE
+              value: "true"
+            - name: BIOMNI_SOURCE
+              value: "Bedrock"
+            - name: BIOMNI_LLM
+              value: "anthropic.claude-sonnet-4-20250514-v1:0"
+            - name: AWS_REGION
+              value: "us-east-1"
+          volumeMounts:
+            - name: aws-creds
+              mountPath: /root/.aws
+              readOnly: true
+          resources:
+            requests:
+              memory: "2Gi"
+            limits:
+              memory: "4Gi"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 7860
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 7860
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 5
+      nodeSelector:
+        workload: "biomni"
+      tolerations:
+        - key: "workload"
+          operator: "Equal"
+          value: "biomni"
+          effect: "NoSchedule"
+      volumes:
+        - name: aws-creds
+          persistentVolumeClaim:
+            claimName: aws-credentials-pvc
+      imagePullSecrets:
+        - name: dockerhub-creds

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni/ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: http
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-body-size: 512m
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  labels:
+    app.kubernetes.io/instance: ingress
+  name: biomni-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: biomni.cbioportal.aws.mskcc.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: biomni
+                port:
+                  number: 7860
+            path: /
+            pathType: Prefix

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni/service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/biomni/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: biomni
+spec:
+  selector:
+    app: biomni
+  ports:
+    - name: gradio
+      port: 7860
+      targetPort: 7860
+    - name: mcp
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/aws-credentials-refresher.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/aws-credentials-refresher.yaml
@@ -98,8 +98,9 @@ spec:
                   # Login
                   saml2aws login --force --skip-prompt
 
-                  # Restart deployment to reset token cache
+                  # Restart deployments to reset token cache
                   kubectl rollout restart deployment cbioagent-librechat
+                  kubectl rollout restart deployment biomni
               envFrom:
                 - secretRef:
                     name: aws-saml-creds

--- a/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
@@ -214,6 +214,23 @@ locals {
         (var.LABEL_KEY) = "cdd"
       }
     }
+    biomni = {
+      instance_types = ["m6i.large"]
+      ami_type       = "BOTTLEROCKET_x86_64"
+      desired_size   = 1
+      max_size       = 1
+      min_size       = 1
+      taints = {
+        dedicated = {
+          key    = var.TAINT_KEY
+          value  = "biomni"
+          effect = var.TAINT_EFFECT
+        }
+      }
+      labels = {
+        (var.LABEL_KEY) = "biomni"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds Biomni (biomedical AI agent) deployment to the 666 (AWS 666628074417) cbioportal-prod EKS cluster
- New x86 EKS node group: 1x `m6i.large` with `workload=biomni:NoSchedule` taint
- Gradio web UI exposed at `biomni.cbioportal.aws.mskcc.org` (port 7860)
- MCP server for LibreChat/cbioagent integration (port 8000, cluster-internal only)
- Uses AWS Bedrock via shared `aws-credentials-pvc` (no extra API keys needed)
- Adds `biomni` deployment restart to existing aws-credentials-refresher cron job

## Files changed
- `iac/.../eks/main.tf` — new `biomni` node group
- `argocd/.../apps/argocd/biomni.yaml` — ArgoCD Application
- `argocd/.../apps/biomni/deployment.yaml` — Deployment (Gradio + MCP, Bedrock)
- `argocd/.../apps/biomni/service.yaml` — ClusterIP Service (7860 + 8000)
- `argocd/.../apps/biomni/ingress.yaml` — Ingress for biomni.cbioportal.aws.mskcc.org
- `argocd/.../apps/cbioagent/aws-credentials-refresher.yaml` — restart biomni on cred refresh

## Dependencies
- Dockerfile PR: https://github.com/snap-stanford/Biomni/pull/292
- Docker image `cbioportal/biomni:latest` needs to be built and pushed first

## Test plan
- [ ] Terraform plan for new node group
- [ ] ArgoCD sync after node group is ready
- [ ] Verify Gradio UI at biomni.cbioportal.aws.mskcc.org
- [ ] Verify MCP endpoint at http://biomni:8000 from within cluster
- [ ] Verify AWS cred refresh restarts biomni pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)