### PR TITLE
Add context compaction strategy for agents endpoint

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -121,6 +121,7 @@ data:
     endpoints:
       agents:
         contextStrategy: 'summarize'
+        # summaryModel: claude-3-5-haiku-20241022
         recursionLimit: 50
         maxRecursionLimit: 100
         disableBuilder: false

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -120,6 +120,7 @@ data:
     # Definition of endpoints
     endpoints:
       agents:
+        contextStrategy: 'summarize'
         recursionLimit: 50
         maxRecursionLimit: 100
         disableBuilder: false


### PR DESCRIPTION
  Summary

  - Add contextStrategy: 'summarize' to the agents endpoint configuration in librechat.yaml
  - This enables context compaction so that long agent conversations are automatically summarized to stay within context limits

  Test plan

  - Verify agents continue to function correctly with context compaction enabled
  - Test long conversations to confirm context summarization kicks in appropriately