### PR TITLE
Add scheduler resource limits to airflow values file

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
@@ -94,6 +94,14 @@ tolerations:
     effect: NoSchedule
 
 scheduler:
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"
+
   extraInitContainers:
     - command:
         - sh


### PR DESCRIPTION
Limit the amount of memory/CPU that the Airflow scheduler can use.