### PR TITLE
Add domains to librechat-config allowlist

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -93,6 +93,9 @@ data:
         - "swapi.dev"
         - "librechat.ai"
         - "google.com"
+        - "clinicaltrials.gov"
+        - "www.ebi.ac.uk"
+        - "query-api.iedb.org"
 
     mcpServers:
       cbioportal-database:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -106,6 +106,9 @@ data:
         - "swapi.dev"
         - "librechat.ai"
         - "google.com"
+        - "clinicaltrials.gov"
+        - "www.ebi.ac.uk"
+        - "query-api.iedb.org"
 
     # MCP Servers Object Structure
     mcpServers:


### PR DESCRIPTION
Allow ClinicalTrials.gov, IPD-IMGT/HLA, and IEDB domains for Actions

LibreChat cant create an Action whose server URL host isn't in actions.allowedDomains, returning HTTP 400 at agent-build time. Add the three domains needed by the NeoCheck agent's HTTP recipes:

  - clinicaltrials.gov     — NIH clinical trial registry v2 API
  - www.ebi.ac.uk          — EBI IPD-IMGT/HLA REST API
  - query-api.iedb.org     — IEDB / CEDAR epitope query API

Applied to both prod (cbioagent) and beta (cbioagent-beta) configs so the agent can be developed against beta before promotion.