### PR TITLE
Stop Argo CD from reverting the cbioagent clone job's ConfigMap flip

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
@@ -25,3 +25,15 @@ spec:
   destination:
     namespace: default
     server: https://kubernetes.default.svc
+  # The cron job cbioagent-clickhouse-clone-daily owns the live value of
+  # data.CLICKHOUSE_DATABASE in this ConfigMap — it patches the field on
+  # every successful clone+flip. Without this entry Argo CD treats the
+  # cron's patch as drift and reverts it back to the seed value, which
+  # silently keeps the MCP pointed at whichever DB was last in git.
+  ignoreDifferences:
+    - group: ""
+      kind: ConfigMap
+      name: clickhouse-mcp-active
+      namespace: default
+      jsonPointers:
+        - /data/CLICKHOUSE_DATABASE


### PR DESCRIPTION
## Summary

The daily cron `cbioagent-clickhouse-clone-daily` rebuilds the inactive librechat buffer and then `kubectl patch`es `clickhouse-mcp-active.data.CLICKHOUSE_DATABASE` to point the MCP at the freshly-built DB. That patch was reliably succeeding (see the cron's `rollout` container logs), but **Argo CD was reverting it on every subsequent sync** because the ConfigMap is in this Application's git tree and the existing `argocd.argoproj.io/sync-options: IgnoreExtraneous=true` annotation is for ignoring *extra resources*, not field-level drift.

Net effect: the MCP has been silently stuck on `cgds_public_librechat_20251209` (the December 2025 manually-built clone) for months, even though both blue/green ping-pong buffers have been getting freshly cloned daily.

## Fix

Add an `ignoreDifferences` entry to the `cbioagent` Argo Application on `/data/CLICKHOUSE_DATABASE` so Argo leaves that one field alone while still managing the rest of the ConfigMap (and the rest of the cbioagent app).

## Follow-ups

- **Pure cleanup** (couldn't include in this PR due to a permission denial in this session): update the now-misleading seed value `CLICKHOUSE_DATABASE: cgds_public_librechat_20251209` → `cbioportal_public_librechat_blue`, and drop the now-dead `argocd.argoproj.io/sync-options: IgnoreExtraneous=true` annotation in `cbioagent-clickhouse-clone-daily.yaml`. Neither blocks this PR — `ignoreDifferences` is what does the real work.
- **Longer-term redesign** tracked in #442 — move the pointer into ClickHouse and run the librechat clone as a step in the existing public-portal import job, matching the public-portal color-flip pattern. Would obsolete this annotation entirely.

## Test plan

- [x] Manually flipped the live ConfigMap to `cbioportal_public_librechat_blue` and rolled the MCP — agent is now reading current portal data + the newly-merged `cancer_study_query_preferences` table (cBioPortal/cbioportal-mcp#48).
- [ ] Sync the `cbioagent` Argo app after this merges; confirm the live `clickhouse-mcp-active` ConfigMap value stays at `cbioportal_public_librechat_blue`.
- [ ] Tomorrow's 13:01 UTC cron run will flip into `_green`; confirm the rollout container's patch persists past the next Argo sync.