### PR TITLE
cron: recurse into sql/portal-specific/ when applying LLM-prep SQL

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-clone-daily.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-clone-daily.yaml
@@ -119,11 +119,18 @@ data:
       clickhouse client $CH_FLAGS --query "CREATE TABLE ${DST_DB}.${t} CLONE AS ${SRC_DB}.${t}"
     done
 
-    # 6) Apply LLM-prep SQL files (numeric-prefix sorted) from the
-    #    fetch-sql initContainer's payload.
-    log "applying LLM-prep SQL files"
+    # 6) Apply LLM-prep SQL files from the fetch-sql initContainer's
+    #    payload. Two phases:
+    #      a) sql/*.sql (portable, numeric order)
+    #      b) sql/portal-specific/<portal>/*.sql for every subdir
+    log "applying LLM-prep SQL files (portable)"
     for f in $(ls /workdir/sql/*.sql 2>/dev/null | sort); do
-      log "  → $(basename "$f")"
+      log "  → $(echo "$f" | sed 's|/workdir/sql/||')"
+      clickhouse client $CH_FLAGS --database "${DST_DB}" --queries-file "$f"
+    done
+    log "applying LLM-prep SQL files (portal-specific)"
+    for f in $(ls /workdir/sql/portal-specific/*/*.sql 2>/dev/null | sort); do
+      log "  → $(echo "$f" | sed 's|/workdir/sql/||')"
       clickhouse client $CH_FLAGS --database "${DST_DB}" --queries-file "$f"
     done
 


### PR DESCRIPTION
## Why

[cBioPortal/cbioportal-mcp#49](https://github.com/cBioPortal/cbioportal-mcp/pull/49) restructures the LLM-prep SQL layout:

- `sql/0-*.sql` through `sql/4-*.sql` are portable across deployments.
- Deployment-tied SQL moves into `sql/portal-specific/<portal-name>/*.sql`. For the public-cBioPortal deployment that's `sql/portal-specific/public-portal/0-preferences.sql`.

The cron's existing apply loop is a flat glob (`ls /workdir/sql/*.sql`) — it won't pick up the subdirectory files. Without this matching update, the next cron-built buffer would have:

- ✅ `cancer_study_query_preferences` table (from `sql/3-*`)
- ✅ `mutation_panel_gene_coverage` / `mutation_wes_coverage` / `gene_mutation_frequency_by_cancer_type` views (from `sql/4-*`)
- ❌ No `all_studies_non_redundant` / `large_genomic_cohort` / `treatment_outcomes` preference rows (was `sql/5-*`, now `sql/portal-specific/public-portal/0-preferences.sql`)

So agent cohort lookups against those preference names would return empty rows.

## Fix

Two-phase apply in `clone.sh`:

1. `sql/*.sql` — portable, numeric order (unchanged behavior).
2. `sql/portal-specific/*/*.sql` — every subdir, numeric order within each.

A deployer image typically only contains one `portal-specific/` subdir but the loop tolerates multiple. No config knob needed; the script just iterates what's there.

## Test plan

- [ ] Merge cBioPortal/cbioportal-mcp#49 first so `cbioportal/mcp:latest` ships the new layout.
- [ ] Merge this PR; sync the `cbioagent` Argo app.
- [ ] Trigger one cron run manually: `kubectl create job --from=cronjob/cbioagent-clickhouse-clone-daily clone-portal-specific-test`.
- [ ] Check the cron's clone-container log shows two `applying LLM-prep SQL files` phases and lists `portal-specific/public-portal/0-preferences.sql` in the second.
- [ ] After the cron flips: `SELECT preference_name, COUNT(*) FROM cancer_study_query_preferences GROUP BY preference_name` should return all four preferences (`all_studies_non_redundant`, `pan_cancer_tcga`, `large_genomic_cohort`, `treatment_outcomes`).