### PR TITLE
Update clickhouse-mcp-active seed to the actual live buffer

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-clone-daily.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-clone-daily.yaml
@@ -27,20 +27,16 @@ kind: ConfigMap
 metadata:
   name: clickhouse-mcp-active
   namespace: default
-  annotations:
-    # The cron updates this on color flips; commit a starting value but
-    # treat live drift as authoritative.
-    argocd.argoproj.io/sync-options: IgnoreExtraneous=true
 data:
-  # Initial seed = the currently-live LLM clone DB. Keeping this value
-  # equal to what the Secret holds on Day 1 means the MCP pod can roll
-  # safely the moment this ConfigMap is added to its envFrom — no read
-  # against a not-yet-built buffer. On the first cron run, clone.sh
-  # falls through to its bootstrap branch (unrecognised value) and
-  # builds cbioportal_public_librechat_blue; rollout.sh then patches
-  # this ConfigMap to that name and rolls the MCP. From there the
-  # buffers ping-pong normally.
-  CLICKHOUSE_DATABASE: cgds_public_librechat_20251209
+  # Initial seed. The cbioagent Argo Application has an ignoreDifferences
+  # entry on /data/CLICKHOUSE_DATABASE so the cron's daily flip isn't
+  # reverted — but in practice empty-string `group: ""` gets stripped on
+  # apply and the matcher fails to fire, so Argo re-asserts this seed on
+  # every sync anyway. Until that's fixed (or until the active-buffer
+  # pointer moves into ClickHouse per #442), keep this value equal to
+  # whichever buffer the MCP should be reading; otherwise every Argo sync
+  # rolls the MCP back to whatever this names. Today: blue.
+  CLICKHOUSE_DATABASE: cbioportal_public_librechat_blue
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## Summary

The `ignoreDifferences` fix from #443 hasn't held in practice — empty `group: ""` gets stripped on apply, the matcher silently fails to identify the ConfigMap, and Argo re-asserts the git seed on every sync. So the seed value in git is effectively what the MCP reads.

Caught after rolling the MCP today for an updated image: pod came up pointed at the legacy `cgds_public_librechat_20251209` (because that's what git named), agent reported the new `cancer_study_query_preferences` table didn't exist (because in the legacy clone it doesn't).

## Fix

Match git's seed to the buffer the MCP should be reading: `cbioportal_public_librechat_blue`. After this merges + Argo sync + MCP roll, the MCP reads the right buffer.

## Caveat

Tomorrow's 13:01 UTC cron will flip into `_green`. The next Argo sync after that will re-assert `_blue` from this seed, leaving the cron's `_green` build idle. Two real fixes worth doing:

- **Make `ignoreDifferences` actually work** — try without `group` (it defaults), or use server-side apply, or use Argo's annotation-based ignore. Smallest change.
- **Move the active-buffer pointer into ClickHouse** per #442 — eliminates the K8s ConfigMap pointer entirely and matches the public-portal color-flip pattern. Right answer, bigger change.

Either is follow-up to this PR.