### PR TITLE
cbioagent: add RespectIgnoreDifferences=true so cron's ConfigMap flip sticks

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
@@ -18,18 +18,23 @@ spec:
         releaseName: cbioagent
         valueFiles:
           - $k8s-repo/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
-#  syncPolicy:
-#    automated:
-#      prune: true
-#      selfHeal: true
+  syncPolicy:
+    # Sync still triggered manually; this option just opts the *next*
+    # sync (whenever it happens) into honoring ignoreDifferences. By
+    # default ignoreDifferences only affects the diff display — Argo's
+    # sync still overwrites ignored fields back to git unless you tell
+    # it otherwise.
+    # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#respect-ignore-difference-configs
+    syncOptions:
+      - RespectIgnoreDifferences=true
   destination:
     namespace: default
     server: https://kubernetes.default.svc
   # The cron job cbioagent-clickhouse-clone-daily owns the live value of
   # data.CLICKHOUSE_DATABASE in this ConfigMap — it patches the field on
-  # every successful clone+flip. Without this entry Argo CD treats the
-  # cron's patch as drift and reverts it back to the seed value, which
-  # silently keeps the MCP pointed at whichever DB was last in git.
+  # every successful clone+flip. Combined with the RespectIgnoreDifferences
+  # sync option above, Argo leaves the cron's patch alone instead of
+  # reverting it to the seed value in cbioagent-clickhouse-clone-daily.yaml.
   ignoreDifferences:
     - group: ""
       kind: ConfigMap


### PR DESCRIPTION
## Why

The `ignoreDifferences` entry added in #443 was supposed to let the daily cron flip the `clickhouse-mcp-active` ConfigMap without Argo reverting it on the next sync. It didn't. The MCP kept getting rolled back to whatever DB the git seed named (`cgds_public_librechat_20251209`), which is why we ended up updating the seed itself in #445 as a band-aid.

Root cause: `ignoreDifferences` only affects the **diff calculation** by default — it makes the resource not show as `OutOfSync` for those fields, but Argo's sync logic still enforces git's value on those fields. From the [Argo docs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#respect-ignore-difference-configs):

> By default ignored differences are only considered in the diff calculation. To make sure that they are also considered during sync, add `RespectIgnoreDifferences=true` to the application's sync options.

So in practice every sync that touched the Application re-applied git's seed value, undoing the cron's `kubectl patch`.

## Fix

Add `syncOptions: [RespectIgnoreDifferences=true]` to the `cbioagent` Application. Sync still triggered manually; this option just opts the *next* sync (whenever it happens) into honoring `ignoreDifferences`.

## After this lands

1. Sync the parent `argocd` app-of-apps so the new `syncOptions` propagates to the live `cbioagent` Application.
2. Sync `cbioagent` itself.
3. Verify: `kubectl patch cm clickhouse-mcp-active --type=merge -p '{"data":{"CLICKHOUSE_DATABASE":"cbioportal_public_librechat_green"}}'`, then sync `cbioagent` again — the patched value should stay, not revert to `_blue` from the seed.
4. Tomorrow's 13:01 UTC cron's `_green` build + flip should then persist across the subsequent Argo sync.

The seed value in `cbioagent-clickhouse-clone-daily.yaml` (currently `cbioportal_public_librechat_blue` from #445) goes back to being just "initial value for first bootstrap" rather than the load-bearing one-source-of-truth it accidentally became.