### PR TITLE
cbioagent-beta: upgrade LibreChat to v0.8.6-rc1-custom-v1

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
@@ -25,3 +25,15 @@ spec:
   destination:
     namespace: default
     server: https://kubernetes.default.svc
+  # The cron job cbioagent-clickhouse-clone-daily owns the live value of
+  # data.CLICKHOUSE_DATABASE in this ConfigMap — it patches the field on
+  # every successful clone+flip. Without this entry Argo CD treats the
+  # cron's patch as drift and reverts it back to the seed value, which
+  # silently keeps the MCP pointed at whichever DB was last in git.
+  ignoreDifferences:
+    - group: ""
+      kind: ConfigMap
+      name: clickhouse-mcp-active
+      namespace: default
+      jsonPointers:
+        - /data/CLICKHOUSE_DATABASE

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -120,9 +120,8 @@ data:
       provider: bedrock
       # Haiku is the standard summarization model — cheaper/faster than the
       # main agent's Sonnet, and summarization doesn't need Sonnet's reasoning.
-      # Matches the original intent of the dropped patch (which had a commented
-      # `summaryModel: claude-3-5-haiku-...` line in prod's old config).
-      model: us.anthropic.claude-3-5-haiku-20241022-v1:0
+      # Paired with the main agent's Sonnet 4.5 (4.x generation parity).
+      model: us.anthropic.claude-haiku-4-5-20251001-v1:0
       trigger:
         type: token_ratio
         value: 0.85

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -118,7 +118,11 @@ data:
     summarization:
       enabled: true
       provider: bedrock
-      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+      # Haiku is the standard summarization model — cheaper/faster than the
+      # main agent's Sonnet, and summarization doesn't need Sonnet's reasoning.
+      # Matches the original intent of the dropped patch (which had a commented
+      # `summaryModel: claude-3-5-haiku-...` line in prod's old config).
+      model: us.anthropic.claude-3-5-haiku-20241022-v1:0
       trigger:
         type: token_ratio
         value: 0.85

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -110,9 +110,21 @@ data:
         url: http://cbioportal-navigator-beta:80/mcp
         chatMenu: false
 
+    # Context summarization (upstream v0.8.5+ native config).
+    # Replaces the old `endpoints.agents.contextStrategy: 'summarize'` patch
+    # that we maintained in v0.8.3-rc1-custom (now dropped). Long-running
+    # agent conversations are summarized when ~85% of the context budget is
+    # used, rather than dropping older messages.
+    summarization:
+      enabled: true
+      provider: bedrock
+      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+      trigger:
+        type: token_ratio
+        value: 0.85
+
     endpoints:
       agents:
-        contextStrategy: 'summarize'
         recursionLimit: 50
         maxRecursionLimit: 100
         disableBuilder: false

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -51,9 +51,11 @@ image:
   repository: cbioportal/librechat
   registry: docker.io
   pullPolicy: Always
-  # Beta runs ahead of prod to validate dep/lib bumps before promotion.
-  # v8 = v7 + @librechat/agents 3.1.50→3.1.68 (matches upstream v0.8.5).
-  tag: "v0.8.3-rc1-custom-v8"
+  # Beta runs ahead of prod to validate the LibreChat upstream upgrade.
+  # custom-v1 = upstream v0.8.6-rc1 + our 37 cBioPortal patches (rebased onto
+  # v0.8.6-rc1). Drops the local context-summarization patches in favor of
+  # upstream's native top-level `summarization:` config (see librechat-config.yaml).
+  tag: "v0.8.6-rc1-custom-v1"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:


### PR DESCRIPTION
## Summary

- Bumps `cbioagent-beta` image tag from `v0.8.3-rc1-custom-v8` to `v0.8.6-rc1-custom-v1` — upstream LibreChat **v0.8.6-rc1** rebased with our 37 cBioPortal patches.
- Migrates context summarization from the dropped local patch (`endpoints.agents.contextStrategy: 'summarize'`) to upstream's new native top-level `summarization:` config block.
- **Beta only.** Prod (`cbioagent/`) stays on `custom-v7` and will be promoted in a follow-up PR after beta soak.

Beta and prod share the same MongoDB, so any upstream DB migrations between v0.8.3 → v0.8.6-rc1 will land on production data when beta rolls. Verify the rollout pod doesn't crashloop on migration.

## Upgrade details

- Custom branch: [`cBioPortal/LibreChat#v0.8.6-rc1-custom-v1`](https://github.com/cBioPortal/LibreChat/tree/v0.8.6-rc1-custom-v1)
- 469 upstream commits between `v0.8.3-rc1` and `v0.8.6-rc1` merged into 37 cBioPortal patches.
- Dropped 3 obsolete commits:
  - `@librechat/agents 3.1.50 → 3.1.68` (upstream now has 3.1.86)
  - 2 local context-summarization patches (now native upstream)
- Image build: [CI run 25997588304](https://github.com/cBioPortal/LibreChat/actions/runs/25997588304) ✅

## Summarization config

The old `contextStrategy: 'summarize'` key is no longer in the upstream schema. Replaced with:

```yaml
summarization:
  enabled: true
  provider: bedrock
  model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
  trigger:
    type: token_ratio
    value: 0.85
```

Trigger value is a reasonable default — may need tuning based on observed conversation-length behavior on beta.

## Test plan

- [ ] ArgoCD `cbioagent-beta` rolls cleanly (no migration crash on shared MongoDB)
- [ ] `https://beta.chat.cbioportal.org` loads, agents list shows cBioDBAgentBeta / cBioNavigatorBeta
- [ ] cBioAgent (Bedrock) responds to a basic query
- [ ] Long conversation triggers summarization (check pod logs for `[summarization]` traces)
- [ ] Langfuse trace shows `userId` (email) + `agent_id` + `agent_name`
- [ ] Product feedback flow: thumbs-down → modal → persists to MongoDB
- [ ] Conversation starters render on landing page
- [ ] HTML in agent description (cBioDBAgentBeta greeting) renders