### PR TITLE
cbioagent: add ServerSideApply=true so RespectIgnoreDifferences takes effect

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
@@ -19,14 +19,18 @@ spec:
         valueFiles:
           - $k8s-repo/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
   syncPolicy:
-    # Sync still triggered manually; this option just opts the *next*
-    # sync (whenever it happens) into honoring ignoreDifferences. By
-    # default ignoreDifferences only affects the diff display — Argo's
-    # sync still overwrites ignored fields back to git unless you tell
-    # it otherwise.
-    # https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#respect-ignore-difference-configs
+    # RespectIgnoreDifferences alone wasn't enough: with the default
+    # client-side apply, Argo sends the whole resource and the API
+    # server's three-way merge clobbers the ignored field back to git.
+    # ServerSideApply lets Argo build the patch from managed-fields and
+    # omit the ignored JSON pointer entirely, so the cron's in-cluster
+    # value survives the sync.
+    # Refs:
+    #   https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#respect-ignore-difference-configs
+    #   https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#server-side-apply
     syncOptions:
       - RespectIgnoreDifferences=true
+      - ServerSideApply=true
   destination:
     namespace: default
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## Why

#446 added `RespectIgnoreDifferences=true` thinking it'd make Argo's sync honor `ignoreDifferences`. Tested live after merge:

```
$ kubectl patch cm clickhouse-mcp-active -p '{"data":{"CLICKHOUSE_DATABASE":"cbioportal_public_librechat_green"}}'
configmap/clickhouse-mcp-active patched
$ # trigger cbioagent sync...
$ kubectl get cm clickhouse-mcp-active -o jsonpath='{.data.CLICKHOUSE_DATABASE}'
cbioportal_public_librechat_blue   # ← REVERTED
```

The sync's operationState confirmed Argo did issue an apply: `"message": "configmap/clickhouse-mcp-active configured"`.

## Root cause

With Argo's default client-side apply, the sync sends the whole resource manifest and the API server's three-way merge enforces all fields — there's no good way to "exclude" a JSON pointer from the apply because the apply has no concept of partial updates.

ServerSideApply works field-by-field via managed-fields. Argo CD with `ServerSideApply=true` + `RespectIgnoreDifferences=true` builds the patch by reading the live resource, computing only the fields it manages, and *omitting* the JSON pointers listed in `ignoreDifferences` from that patch. The field truly becomes "owned by whoever else is writing it" (the cron).

## Test plan

After merge + parent sync + cbioagent sync:

```bash
# Patch CM to a different value than the seed
kubectl patch cm clickhouse-mcp-active -n default --type=merge \
  -p '{"data":{"CLICKHOUSE_DATABASE":"cbioportal_public_librechat_green"}}'

# Sync cbioagent
kubectl patch application cbioagent -n argocd --type=merge \
  -p '{"operation":{"sync":{"revision":"HEAD","prune":false}}}'

# After sync completes, value should STAY green:
kubectl get cm clickhouse-mcp-active -n default -o jsonpath='{.data.CLICKHOUSE_DATABASE}'
```