### PR TITLE
Revert cbioagent-beta to v0.8.3-rc1-custom-v8

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -110,24 +110,9 @@ data:
         url: http://cbioportal-navigator-beta:80/mcp
         chatMenu: false
 
-    # Context summarization (upstream v0.8.5+ native config).
-    # Replaces the old `endpoints.agents.contextStrategy: 'summarize'` patch
-    # that we maintained in v0.8.3-rc1-custom (now dropped). Long-running
-    # agent conversations are summarized when ~85% of the context budget is
-    # used, rather than dropping older messages.
-    summarization:
-      enabled: true
-      provider: bedrock
-      # Haiku is the standard summarization model — cheaper/faster than the
-      # main agent's Sonnet, and summarization doesn't need Sonnet's reasoning.
-      # Paired with the main agent's Sonnet 4.5 (4.x generation parity).
-      model: us.anthropic.claude-haiku-4-5-20251001-v1:0
-      trigger:
-        type: token_ratio
-        value: 0.85
-
     endpoints:
       agents:
+        contextStrategy: 'summarize'
         recursionLimit: 50
         maxRecursionLimit: 100
         disableBuilder: false

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -51,11 +51,9 @@ image:
   repository: cbioportal/librechat
   registry: docker.io
   pullPolicy: Always
-  # Beta runs ahead of prod to validate the LibreChat upstream upgrade.
-  # custom-v1 = upstream v0.8.6-rc1 + our 37 cBioPortal patches (rebased onto
-  # v0.8.6-rc1). Drops the local context-summarization patches in favor of
-  # upstream's native top-level `summarization:` config (see librechat-config.yaml).
-  tag: "v0.8.6-rc1-custom-v1"
+  # Beta runs ahead of prod to validate dep/lib bumps before promotion.
+  # v8 = v7 + @librechat/agents 3.1.50→3.1.68 (matches upstream v0.8.5).
+  tag: "v0.8.3-rc1-custom-v8"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:


### PR DESCRIPTION
## Summary

Reverts beta cbioagent to the pre-upgrade `v0.8.3-rc1-custom-v8` image. The v0.8.6-rc1-custom-v1 upgrade (#447) introduced a **streaming-rendering regression**: native tool_use blocks ARE saved correctly to MongoDB and render fine on conversation reload, but during live streaming the agents-SDK emits the raw Claude `<function_calls>` scratchpad XML as text content, so the UI shows raw XML until the message is finalized.

Also restores the old `endpoints.agents.contextStrategy: 'summarize'` config that v8 expects, removing the upstream-style `summarization:` block (which only applies on v0.8.5+).

## What we tried before reverting

Gated the new Bedrock `fine-grained-tool-streaming-2025-05-14` beta header (upstream PR #12962) behind an env var (cBioPortal/LibreChat commit `dcb2a1c63`, pushed under the same `v0.8.6-rc1-custom-v1` tag) — confirmed it's **not** the cause; XML still streams live. The issue is in `@librechat/agents` 3.1.86's stream emitter itself, not the Bedrock header.

## Follow-up

- Diagnose `@librechat/agents` 3.1.50 → 3.1.86 stream emitter changes
- Check upstream LibreChat issues / dev branch for known reports
- Re-attempt upgrade once a fix is identified

The custom-v1 branch (`cBioPortal/LibreChat:v0.8.6-rc1-custom-v1`) and the upgrade backup tag (`backup/v0.8.6-rc1-custom-pre-merge`) remain in place for follow-up work.

## Test plan

- [ ] Merge → ArgoCD sync `cbioagent-beta`
- [ ] Pod rolls cleanly back to v0.8.3-rc1-custom-v8
- [ ] cBioDBAgentBeta tool calls render properly during live streaming (the symptom that prompted the revert)