### PR TITLE
librechat: disable agents.create for default USER role

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -88,7 +88,18 @@ data:
       prompts: false
       bookmarks: false
       multiConvo: false
-      agents: true
+      # Default USER role: can USE existing agents but not create/share new
+      # ones. mskcc.org users are promoted to a custom AGENT_BUILDER role
+      # in the Roles collection that grants USE + CREATE + SHARE so they
+      # can author agents; full ADMIN stays scoped to actual admins. This
+      # block seeds the USER role's permissions at startup — the seed
+      # upserts only the USER row so the AGENT_BUILDER role and any
+      # already-promoted users are untouched.
+      agents:
+        use: true
+        create: false
+        share: false
+        public: false
       marketplace:
         use: false
       runCode: false


### PR DESCRIPTION
## Why

Goal: only let trusted users (currently MSK team) author new agents; other signups can still **use** the curated agents (cBioDBAgent, cBioNavigator) but not build new ones.

Currently `interface.agents: true` is shorthand for "everything enabled" — every signed-up user can create / share / publish agents. With 300+ users in MongoDB, that's broader than intended.

## What

Flip `interface.agents` from the `true` shorthand to the object form:

```yaml
agents:
  use: true       # everyone can still chat with existing agents
  create: false   # default USER can't build new ones
  share: false
  public: false
```

This seeds the USER role's permissions on librechat pod startup. The seed upserts only the USER row, so the AGENT_BUILDER role + already-promoted users (see ops note below) survive restarts.

## Ops follow-up (manual, post-merge)

After this lands + librechat rolls, in MongoDB:

1. Create an `AGENT_BUILDER` role with `AGENTS = {USE:true, CREATE:true, SHARE:true, SHARE_PUBLIC:false}`.
2. Bump the ~20 existing mskcc.org `USER` accounts to `AGENT_BUILDER`. (3 are already `ADMIN`, they stay.)
3. Verify new external signups land as `USER` and don't see the "Create Agent" UI.

For new mskcc.org signups going forward, there's no automatic promotion yet — an admin bumps them via the admin panel. If volume picks up, we can add a post-signup hook in the LibreChat fork to auto-assign AGENT_BUILDER based on email domain.

## Counts at time of writing

- 308 total users
- 23 mskcc.org users (20 USER, 3 ADMIN)