### PR TITLE
librechat: revert agents to `true` shorthand; restrict USER via mongo

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -88,18 +88,15 @@ data:
       prompts: false
       bookmarks: false
       multiConvo: false
-      # Default USER role: can USE existing agents but not create/share new
-      # ones. mskcc.org users are promoted to a custom AGENT_BUILDER role
-      # in the Roles collection that grants USE + CREATE + SHARE so they
-      # can author agents; full ADMIN stays scoped to actual admins. This
-      # block seeds the USER role's permissions at startup — the seed
-      # upserts only the USER row so the AGENT_BUILDER role and any
-      # already-promoted users are untouched.
-      agents:
-        use: true
-        create: false
-        share: false
-        public: false
+      # `agents: true` only seeds the USE flag on each role; CREATE / SHARE /
+      # SHARE_PUBLIC come from the Roles collection in MongoDB and are NOT
+      # touched on pod restart. Using the object form here (use/create/share/
+      # public) clobbers all four flags on BOTH the USER and ADMIN roles at
+      # every startup (see #450 incident), so we keep the shorthand and
+      # express the per-role CREATE/SHARE policy directly in mongo:
+      #   USER  → CREATE:false, SHARE:false, SHARE_PUBLIC:false
+      #   ADMIN → CREATE:true,  SHARE:true,  SHARE_PUBLIC:true
+      agents: true
       marketplace:
         use: false
       runCode: false


### PR DESCRIPTION
## Bug

#450 used the object form

```yaml
agents:
  use: true
  create: false
  share: false
  public: false
```

to restrict the default USER role's agent-creation rights. Empirically the LibreChat startup seed at pod boot applies that block to **both** USER *and* ADMIN — see `api/server/services/start/interface.js`, which calls `updateAccessPermissions` for `SystemRoles.USER` and `SystemRoles.ADMIN` with the same `loadedInterface.agents` value.

Consequence after the prod pod roll: `ADMIN.permissions.AGENTS.CREATE` got clobbered to `false` too, so accounts like `orgeraj@mskcc.org`, `wangy21@mskcc.org`, `debruiji@mskcc.org` lost the "Create Agent" button despite being ADMINs.

## Fix

Revert prod to the `agents: true` shorthand. Empirically the shorthand seeds only the `USE` flag (pre-#450 snapshot had ADMIN at `USE:true, CREATE:true, SHARE:true, SHARE_PUBLIC:true` with the same shorthand). The CREATE / SHARE / SHARE_PUBLIC flags are expressed per-role directly in MongoDB and persist across pod restarts:

```
USER  → USE:true, CREATE:false, SHARE:false, SHARE_PUBLIC:false
ADMIN → USE:true, CREATE:true,  SHARE:true,  SHARE_PUBLIC:true
```

I've set USER's flags in mongo as part of preparing this PR. ADMIN was restored manually after #450 took effect (so orgeraj/wangy21/debruiji can create again right now after a browser refresh).

## Test plan

- [ ] Merge, sync cbioagent app, roll librechat pod.
- [ ] After roll, query mongo: `USER.AGENTS.CREATE` should still be `false`, `ADMIN.AGENTS.CREATE` should still be `true`. The seed should leave both alone except for USE.
- [ ] Refresh chat.cbioportal.org as a non-mskcc user — no "Create Agent" button.
- [ ] Refresh as one of the promoted ADMINs — Create Agent button reappears.

Beta is already on the shorthand form (unchanged).