### PR TITLE
beta-librechat: drop memory request to 1Gi to fit alongside prod

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -78,8 +78,13 @@ ingress:
   enabled: false
 
 resources:
+  # Lowered from 2Gi → 1Gi so prod + beta can co-tenant the single
+  # `workload=cbioagent` node until #452 lets karpenter provision a
+  # second one. Revert to 2Gi after the karpenter fix. Beta is a
+  # testing instance — if it OOMs at 1Gi during a session, that's a
+  # signal to fix #452 sooner, not to bump the request back.
   requests:
-    memory: 2Gi
+    memory: 1Gi
   limits:
     memory: 4Gi
 


### PR DESCRIPTION
## Why

Beta librechat is currently Pending and has been ~27min:

```
0/30 nodes are available: 1 Insufficient memory, ... 3 node(s) didn't match Pod's node affinity/selector ...
karpenter: Failed to schedule pod, incompatible requirements,
  label "workload" does not have known values (typo of "workload-class"?)
```

The only `workload=cbioagent` node has ~3.2Gi allocatable. Prod librechat (2Gi request) just rolled onto it, and the mcp / dashboard / navigator pods consume the rest. There's no room for beta at 2Gi, and karpenter can't provision a second node until #452 is fixed (NodePool has no `workload` requirement).

## Fix

Drop beta's request to 1Gi so both prod + beta fit on the single node. Limit stays at 4Gi — Node OOM is the only consequence if beta actually exceeds 1Gi during a session, and that would be a signal to escalate #452, not to revert this.

## Revert

After #452 lands and karpenter can provision a second `workload=cbioagent` node, bump back to `2Gi`.