### PR TITLE
beta-librechat: drop memory request 1Gi → 512Mi

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -78,13 +78,13 @@ ingress:
   enabled: false
 
 resources:
-  # Lowered from 2Gi → 1Gi so prod + beta can co-tenant the single
+  # Lowered from 2Gi → 512Mi so prod + beta can co-tenant the single
   # `workload=cbioagent` node until #452 lets karpenter provision a
   # second one. Revert to 2Gi after the karpenter fix. Beta is a
-  # testing instance — if it OOMs at 1Gi during a session, that's a
+  # testing instance — if it OOMs during a session, that's a
   # signal to fix #452 sooner, not to bump the request back.
   requests:
-    memory: 1Gi
+    memory: 512Mi
   limits:
     memory: 4Gi
 


### PR DESCRIPTION
Follow-up to #453.

#453 dropped beta's memory request from 2Gi to 1Gi, but the new beta pod still wouldn't schedule. The cbioagent node has 3209Mi allocatable, 2152Mi already requested (prod librechat 2Gi + ebs-csi 104Mi). 1Gi (1024Mi) should fit in the 1057Mi remaining, but the scheduler still reported "Insufficient memory" — kubelet's system-reserved + eviction-threshold ate the 33Mi margin.

Drop further to 512Mi to leave clear headroom. Beta librechat at idle is well under that; if it climbs higher during a session and OOMs, that's the signal to push #452 (let karpenter provision a second cbioagent node) instead of bumping back up.

After merge + sync, the Pending beta pod should schedule.