### PR TITLE
Expose unified cBioAgent beta config

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -20,7 +20,7 @@ data:
 
     # Custom interface configuration
     interface:
-      customWelcome: "Hey {{user.name}}! Welcome to cBioAgent **BETA** ⚠️ — testing new agent variants. Production is at https://chat.cbioportal.org."
+      customWelcome: "Hey {{user.name}}! Welcome to cBioPortalChat **BETA** ⚠️ — testing new agent variants. Production is at https://chat.cbioportal.org."
       remoteAgents:
         use: true
         create: true
@@ -80,6 +80,7 @@ data:
       bookmarks: false
       multiConvo: false
       agents: true
+      showSwitchAgent: false
       marketplace:
         use: false
       runCode: false
@@ -132,52 +133,51 @@ data:
       refillIntervalUnit: "days"
       refillAmount: 20000000
 
-    # Beta model specs — beta variants only, no prod agents
+    # Beta model specs — unified agent only. The DB and Navigator MCP servers
+    # remain configured above for the unified agent's tools.
     modelSpecs:
       enforce: false
       prioritize: true
       list:
-        - name: "cBioDBAgentBeta"
-          label: "cBioDBAgentBeta - Beta DB agent"
-          description: "Beta variant of cBioDBAgent for testing."
-          iconURL: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(31,140,197)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E"
+        - name: "cBioPortalChatBeta"
+          label: "cBioPortalChat - Explore cBioPortal data and links"
+          default: true
+          description: "Ask cBioPortalChat to explore cBioPortal data, generate cBioPortal links, and answer questions about studies, genes, mutations, clinical attributes, and patient-level results."
+          placeholder: "How can I help you explore cBioPortal?"
+          iconURL: "https://avatars.githubusercontent.com/u/9876251?s=48&v=4"
           showIconInHeader: true
           showIconInMenu: true
-          showSwitchAgent: true
-          preset:
-            endpoint: "agents"
-            agent_id: "agent_5R56OfQfDRxpkvxaKLAqU"
-            maxTokens: 4096
-            thinking: false
-            temperature: 0
-            modelLabel: "cBioDBAgentBeta"
-            greeting: |
-              **BETA** — testing variant of cBioDBAgent. Ask questions below to explore the cBioPortal database. NOTE: Limit of 20 messages per 30 minutes, and 20M tokens per week. <br /><br /><a href="https://docs.cbioportal.org/ai-integrations/chat-interface/" target="_blank" style="display: inline-block; background-color: #4b5563; color: #f9fafb; padding: 8px 16px; border-radius: 8px; text-decoration: none; font-size: 15px; transition: background-color 0.2s ease;" onmouseover="this.style.backgroundColor='#374151'" onmouseout="this.style.backgroundColor='#4b5563'">Learn more</a>
-        - name: "cBioNavigatorBeta"
-          label: "cBioNavigatorBeta - Beta Navigator"
-          default: false
-          description: "Beta variant of cBioNavigator for testing."
-          iconURL: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(31,140,197)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z'/%3E%3Cpath d='M15 5.764v15'/%3E%3Cpath d='M9 3.236v15'/%3E%3C/svg%3E"
-          showIconInHeader: true
-          showIconInMenu: true
-          showSwitchAgent: true
-          preset:
-            endpoint: "agents"
-            agent_id: "agent_rVlFPr2Ho_CKeoQD0dAJY"
-            temperature: 0
-            modelLabel: "cBioNavigatorBeta"
-            greeting: |
-              **BETA** — testing variant of cBioNavigator. Get help navigating the cBioPortal web interface. NOTE: Limit of 20 messages per 30 minutes, and 20M tokens per week. <br /><br /><a href="https://docs.cbioportal.org/ai-integrations/chat-interface/" target="_blank" style="display: inline-block; background-color: #4b5563; color: #f9fafb; padding: 8px 16px; border-radius: 8px; text-decoration: none; font-size: 15px; transition: background-color 0.2s ease;" onmouseover="this.style.backgroundColor='#374151'" onmouseout="this.style.backgroundColor='#4b5563'">Learn more</a>
-        - name: "cBioChatAgentBeta"
-          label: "cBioChatAgentBeta"
-          default: false
-          description: "Unified agent of both DBAgent and Navigator"
-          iconURL: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(31,140,197)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z'/%3E%3Cpath d='M15 5.764v15'/%3E%3Cpath d='M9 3.236v15'/%3E%3C/svg%3E"
-          showIconInHeader: true
-          showIconInMenu: true
-          showSwitchAgent: true
+          showSwitchAgent: false
+          limitBadge:
+            messages: "20 msgs / 30 min"
+            tokens: "20M tokens / week"
+          conversationStarterCategories:
+            - label: "Explore Data"
+              icon: "search"
+              description: "Find studies, datasets, and available molecular data in cBioPortal."
+              starters:
+                - "Which cBioPortal studies include lung adenocarcinoma samples with mutation and copy-number data?"
+                - "Which studies have RNA expression for renal cancer?"
+                - "How many studies have whole exome sequencing data?"
+                - "What TCGA data do you have?"
+            - label: "Navigate cBioPortal"
+              icon: "map"
+              description: "Create direct links to cBioPortal views, cohorts, plots, and study pages."
+              starters:
+                - "Give me an OncoPrint for EGFR and KRAS in TCGA lung adenocarcinoma."
+                - "Can you create a cohort of metastatic prostate cancer with AR amplification?"
+                - "Show me a KM plot of primary vs met prostate cancer in the MSK-IMPACT study."
+            - label: "Analyze Data"
+              icon: "heartbeat"
+              description: "Compare genes, cancer types, molecular profiles, cohorts, and outcomes."
+              starters:
+                - "Show me TP53 mutation frequency across all cancer types."
+                - "What are the most mutated genes in lung cancer?"
+                - "Compare low grade glioma by molecular subtype."
           preset:
             endpoint: "agents"
             agent_id: "agent_OHVSJI9Gd6gwsDnFSL-Xl"
             temperature: 0
-            modelLabel: "cBioChatAgentBeta"
+            modelLabel: "cBioPortalChat"
+            greeting: |
+              Ask cBioPortalChat to explore cBioPortal data, build direct cBioPortal links, and answer questions about studies, genes, mutations, clinical attributes, and patient-level results. <a href="https://docs.cbioportal.org/ai-integrations/chat-interface/" target="_blank">Learn more</a>

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -52,8 +52,13 @@ image:
   registry: docker.io
   pullPolicy: Always
   # Beta runs ahead of prod to validate dep/lib bumps before promotion.
-  # v8 = v7 + @librechat/agents 3.1.50→3.1.68 (matches upstream v0.8.5).
-  tag: "v0.8.3-rc1-custom-v8"
+  # v9 = v8 + merge of cBioPortal/LibreChat#14 (unified UI config), with
+  # the v6/v7 "Switch Agent" landing-page button and agent-selector
+  # tooltip header dropped (no longer needed now that cBioAgent ships a
+  # single unified agent). UI behaviors that used to live in code are
+  # now expressed via librechat.yaml (`interface.showSwitchAgent`,
+  # modelSpec `limitBadge` / `conversationStarterCategories`, etc.).
+  tag: "v0.8.3-rc1-custom-v9"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:


### PR DESCRIPTION
## Summary
- update the cBioAgent beta LibreChat config to expose a single unified `cBioPortalChat` model spec
- configure the cBioPortal GitHub avatar icon, concise selector label, full landing description, default input placeholder, and landing-page limit badge
- simplify the greeting so Learn more is an inline description link rendered by LibreChat rather than a large styled button
- replace separate DB/Navigator examples with categorized cBioPortal capability cards for Explore Data, Navigate cBioPortal, and Analyze Data
- hide switch-agent/model selection affordances for the unified beta experience while preserving MCP server configuration

## Test plan
- `git diff --check`
- parsed `argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml` with Ruby YAML loader
- mirrored config locally in LibreChat and validated via local Docker stack at http://localhost:3080