### PR TITLE
fix: enable Datadog APM port to allow OTLP trace ingestion

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/datadog/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/datadog/values.yaml
@@ -113,6 +113,7 @@ datadog:
     containerCollectAll: true
     enabled: true
   apm:
+    portEnabled: true
     instrumentation:
       skipKPITelemetry: true
   otlp:


### PR DESCRIPTION
Without `apm.portEnabled=true`, the trace-agent does not initialize its OTLP traces pipeline. The embedded OTel collector only registers the metrics handler on port 4318, causing /v1/traces to return 404.

Diagnosed from pod logs showing only data_type:metrics on 0.0.0.0:4318 and 404 errors in the cbioportal-mcp OTel exporter.