### PR TITLE
feat: enable Datadog LLM Observability for cbioagent-clickhouse-mcp

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -31,6 +31,10 @@ spec:
                   fieldPath: status.hostIP
             - name: OTEL_SERVICE_NAME
               value: "cbioportal-mcp"
+            - name: DD_LLMOBS_ML_APP
+              value: "cbioportal-mcp"
+            - name: DD_SITE
+              value: "datadoghq.com"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp


### PR DESCRIPTION
## Summary
- Adds `DD_LLMOBS_ML_APP` and `DD_SITE` env vars to the `cbioagent-clickhouse-mcp` deployment
- `DD_API_KEY` is sourced from the existing `clickhouse-mcp` secret via `envFrom` — no new secretRef needed, just add the key to the existing secret

## Secret change required
Add the following key to the `clickhouse-mcp` secret:
```
DD_API_KEY: <your-datadog-api-key>
```

LLMObs runs in agentless mode (no Datadog agent sidecar required). The existing OpenTelemetry/OTLP tracing pipeline is unaffected. LLM Observability is silently skipped if `DD_API_KEY` is absent.

## Test plan
- [x] Add `DD_API_KEY` to the `clickhouse-mcp` secret
- [ ] Confirm pod restarts cleanly and LLM traces appear at https://app.datadoghq.com/llm/traces?query=@ml_app:cbioportal-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)