### PR TITLE
mcp-cbioportal-ingress: expose cbioportal-mcp at mcp.cbioportal.org/db (rate-limited)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -8,6 +8,37 @@ spec:
     prefixes:
       - /navigator
 ---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-db-prefix
+  namespace: default
+spec:
+  stripPrefix:
+    prefixes:
+      - /db
+---
+# Rate-limit the public database MCP path. Unlike /navigator (which only
+# mints URLs), /db lets clients run arbitrary SELECTs against ClickHouse —
+# cap per-IP throughput so a single client (or scraper) can't DOS the
+# backend. average=2/sec sustained, burst=20 covers a normal chat session
+# firing a handful of tool calls in quick succession.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ratelimit-db
+  namespace: default
+spec:
+  rateLimit:
+    average: 2
+    period: 1s
+    burst: 20
+    sourceCriterion:
+      ipStrategy:
+        depth: 1
+---
+# /navigator — unchanged from the original single-path setup, kept as its
+# own Ingress so its middleware annotation only applies to itself.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -30,6 +61,35 @@ spec:
             backend:
               service:
                 name: cbioportal-navigator
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - mcp.cbioportal.org
+      secretName: mcp-cbio-cert
+---
+# /db — separate Ingress so its own (strip-prefix + rate-limit) middleware
+# chain applies. Same host + same TLS secret; Traefik merges Ingress rules
+# per host.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-cbioportal-db-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: default-strip-db-prefix@kubernetescrd,default-ratelimit-db@kubernetescrd
+  labels:
+    app.kubernetes.io/instance: cbioagent
+spec:
+  rules:
+    - host: mcp.cbioportal.org
+      http:
+        paths:
+          - path: /db
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp
                 port:
                   number: 80
   tls:


### PR DESCRIPTION
## Summary

Adds a public path for the cbioportal-mcp database MCP, mirroring the existing \`/navigator\` path on \`mcp.cbioportal.org\`:

\`\`\`
https://mcp.cbioportal.org/db/mcp  →  cbioagent-clickhouse-mcp:80/mcp
\`\`\`

## Rate limiting

Unlike \`/navigator\` (which only mints cBioPortal URLs), \`/db\` lets clients run arbitrary SELECTs against the production ClickHouse. The data is already public via cbioportal.org, but unbounded query throughput from a single IP is still a DOS risk — so this path also gets a Traefik \`rateLimit\` middleware:

- **average:** 2 req/s sustained per IP
- **burst:** 20 (covers a normal chat session firing a handful of tool calls in a row)
- **sourceCriterion:** \`ipStrategy.depth: 1\` (use the immediate client IP from X-Forwarded-For)

If a single client exceeds the burst, Traefik returns \`429\`. The \`/navigator\` path stays unbounded — minting URLs doesn't hit the backend hard.

## Structural change

The original single Ingress (\`mcp-cbioportal-ingress\`) carried one \`router.middlewares\` annotation that applied to the whole resource. To attach different middleware chains to \`/navigator\` and \`/db\`, I split it into two Ingress resources sharing the same host + TLS secret:

- \`mcp-cbioportal-ingress\` — \`/navigator\` only, strip-prefix only (unchanged behavior)
- \`mcp-cbioportal-db-ingress\` — \`/db\` only, strip-prefix + rate-limit

Traefik merges Ingress rules per host, so both paths show up on the same router.

## Files

- \`argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml\` — new Middlewares (\`strip-db-prefix\`, \`ratelimit-db\`) + new Ingress (\`mcp-cbioportal-db-ingress\`).

## Test plan

After Argo sync:

- [ ] \`kubectl get ingress mcp-cbioportal-db-ingress\` shows the new Ingress with the TLS cert.
- [ ] \`curl -sI https://mcp.cbioportal.org/db/mcp\` returns the FastMCP endpoint headers (not 404).
- [ ] \`curl -sI https://mcp.cbioportal.org/navigator/mcp\` still works as before (no regression).
- [ ] Hammer \`/db\` from one IP: ~25 fast requests → some return \`429\` (rate limit working).
- [ ] Hammer \`/navigator\` similarly → all return 200 (no limit applied).
- [ ] Connect Claude Desktop (or any MCP client) to \`https://mcp.cbioportal.org/db/mcp\` and run a list_studies tool call.

## Out of scope

- Authentication (parity with \`/navigator\` — both are public).
- Per-tool quotas (the rate limit is per-request, not per-query-complexity).
- Beta hostname mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)