### PR TITLE
feat: enable Datadog LLM Observability for LibreChat

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -15,6 +15,11 @@ librechat:
     # values (beta.chat.cbioportal.org) with these prod URLs.
     DOMAIN_CLIENT: "https://chat.cbioportal.org"
     DOMAIN_SERVER: "https://chat.cbioportal.org"
+    NODE_OPTIONS: "--require dd-trace/init"
+    DD_LLMOBS_ENABLED: "1"
+    DD_LLMOBS_ML_APP: "cbioagent"
+    DD_LLMOBS_AGENTLESS_ENABLED: "true"
+    DD_SITE: "datadoghq.com"
   imageVolume:
     accessModes: ReadWriteMany
     storageClassName: efs-sc


### PR DESCRIPTION
## Summary
- Adds `NODE_OPTIONS`, `DD_LLMOBS_*` env vars to the LibreChat deployment via `values.yaml`
- Uses `dd-trace` auto-instrumentation (`--require dd-trace/init`) to capture Anthropic/OpenAI token and cost metrics without code changes
- `ml_app` set to `cbioagent` (separate from `cbioportal-mcp`) for clean cost attribution

## Secret change required
Add `DD_API_KEY` to the existing `librechat-credentials-env` secret (already mounted via `envFrom`):
```
DD_API_KEY: <your-datadog-api-key>
```

## Depends on
- cBioPortal/LibreChat#<PR> — adds `dd-trace` to the image

## Test plan
- [ ] Add `DD_API_KEY` to `librechat-credentials-env` secret
- [ ] Deploy new LibreChat image (with `dd-trace` installed)
- [ ] Confirm token/cost data appears at https://app.datadoghq.com/llm/traces?query=@ml_app:cbioagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)