### PR TITLE
Add cedar-api.iedb.org to LibreChat actions.allowedDomains

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -97,6 +97,7 @@ data:
         - "clinicaltrials.gov"
         - "www.ebi.ac.uk"
         - "query-api.iedb.org"
+        - "cedar-api.iedb.org"
 
     mcpServers:
       cbioportal-database:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -104,6 +104,7 @@ data:
         - "clinicaltrials.gov"
         - "www.ebi.ac.uk"
         - "query-api.iedb.org"
+        - "cedar-api.iedb.org"
 
     mcpServers:
       cbioportal-database:


### PR DESCRIPTION
## What

Add `cedar-api.iedb.org` to `actions.allowedDomains` in the LibreChat
ConfigMaps for both `cbioagent` and `cbioagent-beta`.

## Why

CEDAR (Cancer Epitope Database) is the cancer-focused subset of IEDB,
served via PostgREST at `https://cedar-api.iedb.org`. Unlike the already
allowlisted general API (`query-api.iedb.org`), CEDAR exposes a native
somatic-mutation field (`mutation`) and neoantigen flags, which the
NeoCheck research agent needs to look up T-cell / MHC evidence for a
specific variant (e.g. `mutation=eq.V600E`) without approximating via
gene-name + disease filters.

`query-api.iedb.org` is retained for any general (non-cancer) IEDB use.

## Change

Two files, one line each — appended after the existing
`query-api.iedb.org` entry:

```diff
         - "query-api.iedb.org"
+        - "cedar-api.iedb.org"
```

- `argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml`
- `argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml`

No other configuration is touched.
