### PR TITLE
feat: add librechat-exporter for Prometheus token/usage metrics

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-exporter.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-exporter.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         run: librechat-exporter
+        tags.datadoghq.com/env: "public"
+        tags.datadoghq.com/service: "librechat"
+        tags.datadoghq.com/version: "v0.8.3"
       annotations:
         # Datadog autodiscovery: scrape Prometheus metrics from this pod
         ad.datadoghq.com/librechat-exporter.checks: |

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-exporter.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-exporter.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: librechat-exporter
+  labels:
+    run: librechat-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: librechat-exporter
+  template:
+    metadata:
+      labels:
+        run: librechat-exporter
+      annotations:
+        # Datadog autodiscovery: scrape Prometheus metrics from this pod
+        ad.datadoghq.com/librechat-exporter.checks: |
+          {
+            "openmetrics": {
+              "instances": [
+                {
+                  "openmetrics_endpoint": "http://%%host%%:8000/metrics",
+                  "namespace": "librechat",
+                  "metrics": [".*"]
+                }
+              ]
+            }
+          }
+    spec:
+      containers:
+        - name: librechat-exporter
+          image: ghcr.io/virtuos/librechat_exporter:main
+          ports:
+            - containerPort: 8000
+          env:
+            # Rename MONGO_URI (LibreChat's key) to MONGODB_URI (exporter's key)
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: librechat-credentials-env
+                  key: MONGO_URI
+            - name: MONGODB_DATABASE
+              value: "LibreChat"
+            - name: ENABLE_BASIC_METRICS
+              value: "true"
+            - name: ENABLE_TOKEN_METRICS
+              value: "true"
+            - name: ENABLE_RATING_METRICS
+              value: "true"
+            - name: METRICS_CACHE_ENABLED
+              value: "true"
+            - name: METRICS_CACHE_TTL
+              value: "60"
+      nodeSelector:
+        workload: "cbioagent"
+      tolerations:
+        - key: "workload"
+          operator: "Equal"
+          value: "cbioagent"
+          effect: "NoSchedule"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: librechat-exporter
+spec:
+  selector:
+    run: librechat-exporter
+  ports:
+    - port: 8000
+      name: metrics
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- Adds `librechat-exporter` Deployment + Service to the cbioagent stack
- Uses `ghcr.io/virtuos/librechat_exporter:main` to expose token usage, user activity, and rating metrics from LibreChat's MongoDB as Prometheus/OpenMetrics
- Datadog autodiscovery annotation on the pod enables automatic scraping under the `librechat.*` metric namespace — no Datadog agent config changes needed
- `MONGO_URI` (LibreChat's secret key) is remapped to `MONGODB_URI` (exporter's expected key) via `valueFrom.secretKeyRef`

## No secret changes required
`MONGO_URI` is already in the existing `librechat-credentials-env` secret.

## Metrics available after deploy
Metrics will appear in Datadog under `librechat.*`, including:
- Token usage per user/model
- Registered and active user counts
- Message and rating counts

These can be used to build custom cost/usage dashboards in Datadog Metrics Explorer.

## Test plan
- [x] Pod starts and reaches Ready state
- [x] `kubectl exec` into pod and `curl localhost:8000/metrics` returns `librechat_*` metrics
- [x] Metrics appear in Datadog under `librechat.*` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)