### PR TITLE
fix: set MONGODB_DATABASE to cBioAgent for librechat-exporter

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-exporter.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-exporter.yaml
@@ -44,7 +44,7 @@ spec:
                   name: librechat-credentials-env
                   key: MONGO_URI
             - name: MONGODB_DATABASE
-              value: "LibreChat"
+              value: "cBioAgent"
             - name: ENABLE_BASIC_METRICS
               value: "true"
             - name: ENABLE_TOKEN_METRICS


### PR DESCRIPTION
## Summary

- The `MONGO_URI` in `librechat-credentials-env` connects to and authenticates against the `cBioAgent` database
- `MONGODB_DATABASE` was set to `"LibreChat"`, causing the exporter to query a different database the user has no access to
- This resulted in `Unauthorized` (MongoDB code 13) errors on every collection query (`messages`, `conversations`, `files`, `users`), so all token/message/user/rating metrics were failing silently

## Test plan

- [ ] After ArgoCD syncs, confirm the `librechat-exporter` pod restarts without MongoDB auth errors in logs
- [ ] Confirm `librechat_input_tokens_total` and `librechat_output_tokens_total` metrics appear in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)