### PR TITLE
feat: add Datadog unified service tagging labels to LibreChat pods

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -39,6 +39,11 @@ librechat-rag-api:
   postgresql:
     enabled: true
 
+podLabels:
+  tags.datadoghq.com/env: "public"
+  tags.datadoghq.com/service: "librechat"
+  tags.datadoghq.com/version: "v0.8.3"
+
 nodeSelector:
   workload: cbioagent
 


### PR DESCRIPTION
## Summary

- Adds `tags.datadoghq.com/env`, `tags.datadoghq.com/service`, and `tags.datadoghq.com/version` pod labels to the LibreChat deployment via `podLabels` in `values.yaml`
- Required for Datadog to correlate traces, metrics, and logs under unified service tagging
- Consistent with the labels already applied to the `librechat-exporter` pod

## Test plan

- [ ] After ArgoCD syncs, confirm LibreChat pods have the `tags.datadoghq.com/*` labels
- [ ] Confirm Datadog traces for `cbioagent` show `env:public` and `version:v0.8.3` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)