### PR TITLE
cbioagent-mcp: mount FastMCP at /db/mcp natively, drop strip-db-prefix

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -35,6 +35,12 @@ spec:
               value: "cbioportal-mcp"
             - name: DD_SITE
               value: "datadoghq.com"
+            # Mount FastMCP under the external sub-path so trailing-slash
+            # redirects point to https://mcp.cbioportal.org/db/mcp/ rather
+            # than /mcp/. Paired with dropping the strip-db-prefix
+            # middleware on the mcp-cbioportal-db-ingress Ingress.
+            - name: CLICKHOUSE_MCP_HTTP_PATH
+              value: "/db/mcp"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -8,16 +8,6 @@ spec:
     prefixes:
       - /navigator
 ---
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: strip-db-prefix
-  namespace: default
-spec:
-  stripPrefix:
-    prefixes:
-      - /db
----
 # Rate-limit the public database MCP path. Unlike /navigator (which only
 # mints URLs), /db lets clients run arbitrary SELECTs against ClickHouse —
 # cap per-IP throughput so a single client (or scraper) can't DOS the
@@ -68,16 +58,18 @@ spec:
         - mcp.cbioportal.org
       secretName: mcp-cbio-cert
 ---
-# /db — separate Ingress so its own (strip-prefix + rate-limit) middleware
-# chain applies. Same host + same TLS secret; Traefik merges Ingress rules
-# per host.
+# /db — separate Ingress so its own rate-limit middleware only applies
+# here. Same host + same TLS secret; Traefik merges Ingress rules per
+# host. The path is NOT stripped — FastMCP is configured (via the
+# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp) to mount
+# itself at /db/mcp so trailing-slash redirects build correct URLs.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mcp-cbioportal-db-ingress
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.middlewares: default-strip-db-prefix@kubernetescrd,default-ratelimit-db@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: default-ratelimit-db@kubernetescrd
   labels:
     app.kubernetes.io/instance: cbioagent
 spec:


### PR DESCRIPTION
## Summary

- Adds `CLICKHOUSE_MCP_HTTP_PATH=/db/mcp` to the `cbioagent-clickhouse-mcp` Deployment so FastMCP mounts itself at `/db/mcp` instead of `/mcp`.
- Drops the `strip-db-prefix` Traefik Middleware and removes its annotation from `mcp-cbioportal-db-ingress`. The `ratelimit-db` middleware stays.
- Follow-up to #470 (cbioportal/cbioportal-mcp#73 added the env-var pass-through; image is already on `cbioportal/mcp:latest`).

## Why

After #470, `https://mcp.cbioportal.org/db/mcp` (no trailing slash) returns a broken 307 to `http://mcp.cbioportal.org/mcp/` — wrong path and wrong scheme. The strip-prefix means FastMCP saw `/mcp` internally and generated its trailing-slash redirect from the wrong base. Mounting at `/db/mcp` natively fixes both.

## Test plan

- [ ] After Argo sync + pod roll:
  - [ ] `curl -i https://mcp.cbioportal.org/db/mcp` → 307 to `https://mcp.cbioportal.org/db/mcp/` (not `http://.../mcp/`)
  - [ ] `curl -sI https://mcp.cbioportal.org/db/mcp/` → 405 with `mcp-session-id` header (existing behavior)
  - [ ] `curl -sI https://mcp.cbioportal.org/navigator/mcp` → 405 (unchanged)
  - [ ] Floods of `curl https://mcp.cbioportal.org/db/mcp/` > 20 in <1s start returning 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)