### PR TITLE
cbioagent-mcp (msk): expose database MCP at mcp.cbioportal.aws.mskcc.org/db

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -20,6 +20,14 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
+          env:
+            # Mount FastMCP under the external sub-path so trailing-slash
+            # redirects point to https://mcp.cbioportal.aws.mskcc.org/db/mcp/
+            # rather than /mcp/. Paired with the mcp-cbioportal-db-ingress
+            # Ingress in this app: NO rewrite-target so the app sees the
+            # full external path.
+            - name: CLICKHOUSE_MCP_HTTP_PATH
+              value: "/db/mcp"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -1,0 +1,38 @@
+# Public database MCP for the MSK account, mirroring the cBioPortal Public
+# exposure at mcp.cbioportal.org/db. FastMCP is mounted at /db/mcp via the
+# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp, so this
+# Ingress does NOT use rewrite-target — the app sees the full path and
+# generates correct trailing-slash redirects.
+#
+# Rate-limit: 2 req/s sustained per IP, 20 concurrent connections per IP
+# (mirrors the Traefik 2 rps / burst 20 cap on the 203 account).
+#
+# Prereq: DNS for mcp.cbioportal.aws.mskcc.org must point at the same
+# nginx-ingress NLB as the other *.cbioportal.aws.mskcc.org hosts.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-cbioportal-db-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: http
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/limit-rps: "2"
+    nginx.ingress.kubernetes.io/limit-connections: "20"
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  labels:
+    app.kubernetes.io/instance: cbioagent
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: mcp.cbioportal.aws.mskcc.org
+      http:
+        paths:
+          - path: /db
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary

Mirrors the cBioPortal Public exposure from #470 + #478 over to the MSK (666) account.

- Adds `CLICKHOUSE_MCP_HTTP_PATH=/db/mcp` env var to `cbioagent-clickhouse-mcp` in the 666 account. Image is already `cbioportal/mcp:latest`, so the rolling restart picks up the env-var support from cbioportal/cbioportal-mcp#73.
- Adds `mcp-ingress.yaml`: new nginx Ingress for `mcp.cbioportal.aws.mskcc.org/db` → `cbioagent-clickhouse-mcp:80` with `limit-rps=2` and `limit-connections=20` (matching the Traefik 2 rps / burst 20 cap on the 203 account).

No `rewrite-target` annotation — FastMCP owns the full external path so trailing-slash redirects come out correct (the same fix pattern as #478).

## Prereq before this works end-to-end

DNS for `mcp.cbioportal.aws.mskcc.org` must point at the same nginx-ingress NLB that serves `chat.cbioportal.aws.mskcc.org`. Argo will sync the manifests once merged, but the host will fail to resolve (or 502) until DNS is up. May need a Route53 record request.

## Test plan

After merge + Argo sync + DNS:

- [ ] `curl -i https://mcp.cbioportal.aws.mskcc.org/db/mcp` → 307 to `https://mcp.cbioportal.aws.mskcc.org/db/mcp/`
- [ ] `curl -sI https://mcp.cbioportal.aws.mskcc.org/db/mcp/` → 405 with `mcp-session-id` header
- [ ] Add as VS Code MCP server (`type: http`, URL above) and call a tool successfully
- [ ] Flood >20 req/s from one IP starts returning 503/429

🤖 Generated with [Claude Code](https://claude.com/claude-code)