### PR TITLE
HOTFIX: revert msk CLICKHOUSE_MCP_HTTP_PATH (chat broke)

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -20,14 +20,6 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
-          env:
-            # Mount FastMCP under the external sub-path so trailing-slash
-            # redirects point to https://mcp.cbioportal.aws.mskcc.org/db/mcp/
-            # rather than /mcp/. Paired with the mcp-cbioportal-db-ingress
-            # Ingress in this app: NO rewrite-target so the app sees the
-            # full external path.
-            - name: CLICKHOUSE_MCP_HTTP_PATH
-              value: "/db/mcp"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -1,8 +1,17 @@
 # Public database MCP for the MSK account, mirroring the cBioPortal Public
-# exposure at mcp.cbioportal.org/db. FastMCP is mounted at /db/mcp via the
-# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp, so this
-# Ingress does NOT use rewrite-target — the app sees the full path and
-# generates correct trailing-slash redirects.
+# exposure at mcp.cbioportal.org/db.
+#
+# NOTE: This leaves FastMCP at its default mount path /mcp because the
+# in-cluster LibreChat config in portal-configuration still points at
+# http://cbioagent-clickhouse-mcp:80/mcp (changing the mount path broke
+# chat — see incident on 2026-06-10). To get a clean /db/mcp redirect
+# externally we'd need a coordinated change: bump LibreChat config to
+# /db/mcp AND set CLICKHOUSE_MCP_HTTP_PATH=/db/mcp here. Tracked separately.
+#
+# Workaround for now: nginx strips /db before forwarding to the service
+# so external /db/mcp lands at FastMCP's /mcp. Trailing-slash redirect
+# on the bare /db/mcp will be broken (will point at /mcp/), but clients
+# that use the trailing slash work fine.
 #
 # Rate-limit: 2 req/s sustained per IP, 20 concurrent connections per IP
 # (mirrors the Traefik 2 rps / burst 20 cap on the 203 account).
@@ -20,6 +29,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/limit-rps: "2"
     nginx.ingress.kubernetes.io/limit-connections: "20"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
   labels:
     app.kubernetes.io/instance: cbioagent
@@ -29,8 +39,8 @@ spec:
     - host: mcp.cbioportal.aws.mskcc.org
       http:
         paths:
-          - path: /db
-            pathType: Prefix
+          - path: /db(/|$)(.*)
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: cbioagent-clickhouse-mcp


### PR DESCRIPTION
## What broke

#479 set \`CLICKHOUSE_MCP_HTTP_PATH=/db/mcp\` on the MSK \`cbioagent-clickhouse-mcp\` deployment, mounting FastMCP at \`/db/mcp\` instead of the default \`/mcp\`.

The in-cluster LibreChat config (in portal-configuration) still calls \`http://cbioagent-clickhouse-mcp:80/mcp\`, so chat.cbioportal.aws.mskcc.org started 404-ing immediately. User reported a flood of:

\`\`\`
INFO:     10.1.140.109:50544 - "POST /mcp HTTP/1.1" 404 Not Found
\`\`\`

## What this PR does

- Drops \`CLICKHOUSE_MCP_HTTP_PATH\` from the deployment so FastMCP goes back to \`/mcp\`.
- Updates \`mcp-ingress.yaml\` to nginx-strip \`/db\` (\`rewrite-target: /\$2\` with path \`/db(/|\$)(.*)\`), so the public endpoint \`mcp.cbioportal.aws.mskcc.org/db/mcp\` keeps routing to FastMCP's \`/mcp\`.
- Already live-patched in cluster (\`kubectl set env ... CLICKHOUSE_MCP_HTTP_PATH-\`) — Argo will reconcile when this merges.

## Tradeoff

External clients hitting \`/db/mcp\` (no trailing slash) get a broken 307 back to \`/mcp/\` — matches the 203 setup pre-#478. Clients that use the trailing slash (\`/db/mcp/\`) work.

## Proper fix-forward later

Coordinated PR across two repos:
1. portal-configuration: change the LibreChat \`mcpServers.cbioportal-database.url\` to \`http://cbioagent-clickhouse-mcp:80/db/mcp\`.
2. this repo: re-add \`CLICKHOUSE_MCP_HTTP_PATH=/db/mcp\` and drop the rewrite-target.
3. Same coordinated change for the 203 account (the LibreChat there points at \`/mcp\` too — only 203 hasn't broken because clients haven't pounded the no-slash variant... let me actually verify that didn't break too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)