### PR TITLE
cbioagent librechat-config: point mcpServers at /db/mcp (chat hotfix)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -102,7 +102,7 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        url: http://cbioagent-clickhouse-mcp:80/mcp
+        url: http://cbioagent-clickhouse-mcp:80/db/mcp
       cbioportal-navigator:
         type: streamable-http
         url: http://cbioportal-navigator:80/mcp

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -109,7 +109,7 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        url: http://cbioagent-clickhouse-mcp:80/mcp
+        url: http://cbioagent-clickhouse-mcp:80/db/mcp
       cbioportal-navigator:
         type: streamable-http
         url: http://cbioportal-navigator:80/mcp


### PR DESCRIPTION
## What this fixes

After #478 mounted FastMCP at \`/db/mcp\` via \`CLICKHOUSE_MCP_HTTP_PATH=/db/mcp\` on \`cbioagent-clickhouse-mcp\`, the in-cluster LibreChat calls to \`http://cbioagent-clickhouse-mcp:80/mcp\` started 404-ing. Both \`chat.cbioportal.org\` and \`beta.chat.cbioportal.org\` went down.

This PR bumps the \`mcpServers.cbioportal-database.url\` for both prod and beta to \`/db/mcp\` to match the new mount point.

## Already mitigated live

I already applied the change directly to the cluster (configmap apply + \`kubectl rollout restart deploy/cbioagent-librechat\`). Both hosts are responding again. This commit makes the change durable so Argo doesn't revert it.

Logs went from \`POST /mcp 404\` to \`POST /db/mcp/ 200 OK\` after restart.

## Companion PR

[portal-configuration PR forthcoming] does the same for the MSK (666) LibreChat config (\`secrets/cbioagent/librechat-config.yaml\`). Same incident, same fix.

## Also closing

#480 (revert-msk-mcp-http-path) - we're fixing forward instead of reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)