### PR TITLE
cbioagent-mcp (msk): serve MCP at chat.cbioportal.aws.mskcc.org/db

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -1,18 +1,23 @@
-# Public database MCP for the MSK account, mirroring the cBioPortal Public
-# exposure at mcp.cbioportal.org/db. FastMCP is mounted at /db/mcp via the
-# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp, so this
-# Ingress does NOT use rewrite-target — the app sees the full path and
-# generates correct trailing-slash redirects.
+# Public database MCP for the MSK account, served as a sub-path of the
+# existing chat host (chat.cbioportal.aws.mskcc.org/db/mcp) to avoid the
+# DNS dependency on a separate mcp.* hostname. nginx-ingress merges
+# Ingresses per host, so this lives alongside cbioagent-ingress (which
+# owns /) without conflict — nginx picks the longest-prefix match.
+#
+# This Ingress intentionally does NOT use rewrite-target. The sibling
+# cbioagent-ingress rewrites everything to /, which would clobber the
+# /db/mcp path. By splitting into a separate Ingress, that rewrite
+# doesn't apply here. FastMCP is mounted at /db/mcp via the
+# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp, so the
+# full external path is preserved end-to-end and trailing-slash redirects
+# build correct URLs.
 #
 # Rate-limit: 2 req/s sustained per IP, 20 concurrent connections per IP
 # (mirrors the Traefik 2 rps / burst 20 cap on the 203 account).
-#
-# Prereq: DNS for mcp.cbioportal.aws.mskcc.org must point at the same
-# nginx-ingress NLB as the other *.cbioportal.aws.mskcc.org hosts.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: mcp-cbioportal-db-ingress
+  name: cbioagent-db-ingress
   namespace: default
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: http
@@ -26,7 +31,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: mcp.cbioportal.aws.mskcc.org
+    - host: chat.cbioportal.aws.mskcc.org
       http:
         paths:
           - path: /db


### PR DESCRIPTION
## Summary

Sidesteps the DNS dependency on a separate \`mcp.cbioportal.aws.mskcc.org\` hostname by serving the public MCP at a sub-path of the existing chat host instead.

- Renames the Ingress \`mcp-cbioportal-db-ingress\` → \`cbioagent-db-ingress\` and points it at \`chat.cbioportal.aws.mskcc.org/db\` → \`cbioagent-clickhouse-mcp:80\`.
- No \`rewrite-target\`. The sibling \`cbioagent-ingress\` on the same host uses \`rewrite-target: /\` which would clobber \`/db/mcp\` → \`/\`. Splitting into two Ingresses avoids that — nginx merges per host but evaluates rewrites per Ingress.
- Rate-limit and other annotations unchanged from the prior \`mcp.*\` version.

## Why

Neither the 666 nor the 203 AWS account hosts the \`cbioportal.aws.mskcc.org\` Route53 zone — it's owned by MSK central DNS. A new record (\`mcp.cbioportal.aws.mskcc.org\` → NLB) would have been an ops ticket. Reusing \`chat.cbioportal.aws.mskcc.org\` removes that dependency entirely.

## Test plan

After merge + Argo sync:

- [ ] From MSK network: \`curl -i https://chat.cbioportal.aws.mskcc.org/db/mcp/\` → 405 with \`mcp-session-id\` header
- [ ] \`curl -i https://chat.cbioportal.aws.mskcc.org/\` → unchanged (still hits LibreChat 200)
- [ ] VS Code MCP config with \`https://chat.cbioportal.aws.mskcc.org/db/mcp/\` connects and lists tools
- [ ] No regression on in-cluster LibreChat → MCP (still hits \`http://cbioagent-clickhouse-mcp:80/db/mcp\` via Service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)