### PR TITLE
fix: set DD_ENV and DD_VERSION for LibreChat ddtrace

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -16,6 +16,8 @@ librechat:
     DOMAIN_CLIENT: "https://chat.cbioportal.org"
     DOMAIN_SERVER: "https://chat.cbioportal.org"
     NODE_OPTIONS: "--require dd-trace/init"
+    DD_ENV: "public"
+    DD_VERSION: "v0.8.3"
     DD_LLMOBS_ENABLED: "1"
     DD_LLMOBS_ML_APP: "cbioagent"
     DD_LLMOBS_AGENTLESS_ENABLED: "true"


### PR DESCRIPTION
## Summary

- Adds `DD_ENV: "public"` and `DD_VERSION: "v0.8.3"` to `configEnv` in `values.yaml`
- In agentless mode (`DD_LLMOBS_AGENTLESS_ENABLED: "true"`), ddtrace sends directly to Datadog's intake and bypasses the Datadog agent — so `tags.datadoghq.com/*` pod labels are never injected into traces. `DD_ENV` and `DD_VERSION` must be set explicitly as env vars
- Without `DD_VERSION`, ddtrace auto-detects it from `package.json` as `v0.8.3-rc1` instead of the clean `v0.8.3`

## Test plan

- [ ] After ArgoCD syncs, confirm traces show `env:public` and `version:v0.8.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)