### PR TITLE
cbioagent-mcp: trust forwarded proto for HTTPS redirects

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -41,6 +41,10 @@ spec:
             # middleware on the mcp-cbioportal-db-ingress Ingress.
             - name: CLICKHOUSE_MCP_HTTP_PATH
               value: "/db/mcp"
+            # Trust Traefik's X-Forwarded-* headers so Starlette/FastMCP
+            # builds external redirects with the original HTTPS scheme.
+            - name: FORWARDED_ALLOW_IPS
+              value: "*"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp


### PR DESCRIPTION
## Summary
- set `FORWARDED_ALLOW_IPS=*` on `cbioagent-clickhouse-mcp` so Uvicorn trusts Traefik `X-Forwarded-*` headers
- keeps the PR #478 `/db/mcp` native mount while making trailing-slash redirects preserve the external HTTPS scheme

## Why
`https://mcp.cbioportal.org/db/mcp` currently returns `307 Location: http://mcp.cbioportal.org/db/mcp/`. FastMCP/Starlette builds that redirect from the ASGI request scheme. Uvicorn has proxy header support enabled by default, but only trusts `127.0.0.1` unless `FORWARDED_ALLOW_IPS` is configured; Traefik reaches the pod from a non-loopback pod IP.

## Test plan
- `ruby -e 'require "yaml"; YAML.load_stream(File.read("argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml")); YAML.load_stream(File.read("argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml")); puts "yaml ok"'`\n- `git diff --check`\n- Before this change is deployed, observed live behavior: `curl -sS -o /dev/null -D - https://mcp.cbioportal.org/db/mcp` returns `Location: http://mcp.cbioportal.org/db/mcp/`\n- After Argo sync + pod roll, verify: `curl -sS -o /dev/null -D - https://mcp.cbioportal.org/db/mcp` returns `Location: https://mcp.cbioportal.org/db/mcp/`\n- Re-run bounded rate-limit check from #478: an 80-request concurrent probe to `/db/mcp/` should include `429`, and a post-cooldown single request should return normal MCP behavior (`406` with `mcp-session-id`)\n\nStacked on #478.