### PR TITLE
cbioagent (msk): add Kustomize Argo App for MSK ConfigMaps

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/cbioagent-msk-configmaps.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/cbioagent-msk-configmaps.yaml
@@ -1,0 +1,33 @@
+# Deploys the MSK-private ConfigMaps used by the cbioagent clone CronJob
+# (cbioagent-clone-sql-msk) and the MCP Deployment
+# (cbioagent-study-guides-msk). Source content lives as real .sql / .md
+# files in portal-configuration's
+# argocd/aws/666628074417/.../secrets/cbioagent/msk-configmaps/ subdir,
+# and a kustomization.yaml in that subdir uses configMapGenerator to
+# build the ConfigMaps at sync time. GitHub renders the .md natively
+# and the .sql is no longer buried in YAML quoting.
+#
+# Companion change in portal-configuration.yaml (the main Argo
+# Application for portal-configuration): the corresponding source
+# excludes secrets/cbioagent/msk-configmaps/** so it doesn't try to
+# apply kustomization.yaml as a plain manifest.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cbioagent-msk-configmaps
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/knowledgesystems/portal-configuration
+    path: argocd/aws/666628074417/clusters/cbioportal-prod/secrets/cbioagent/msk-configmaps
+    targetRevision: HEAD
+    # No explicit `kustomize:` block needed — Argo auto-detects a
+    # kustomization.yaml in the source path and renders accordingly.
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/portal-configuration.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/portal-configuration.yaml
@@ -11,6 +11,12 @@ spec:
       targetRevision: HEAD
       directory:
         recurse: true
+        # Kustomize-built ConfigMaps live in this subdir and are
+        # deployed by a dedicated Argo Application
+        # (cbioagent-msk-configmaps). Exclude here so this directory
+        # source doesn't try to apply kustomization.yaml + raw
+        # .sql/.md files as plain manifests.
+        exclude: 'secrets/cbioagent/msk-configmaps/**'
     - repoURL: https://github.com/knowledgesystems/portal-configuration
       path: argocd/aws/shared
       targetRevision: HEAD


### PR DESCRIPTION
## Summary

Pairs with [portal-configuration#20](https://github.com/knowledgesystems/portal-configuration/pull/20) (now updated to a Kustomize subdir): wires the new \`secrets/cbioagent/msk-configmaps/\` subdir into Argo so the MSK ConfigMaps are built from real \`.sql\` / \`.md\` files rather than embedded in YAML.

- **New Application** \`cbioagent-msk-configmaps\` points at the Kustomize subdir. Argo auto-detects \`kustomization.yaml\` and builds the two ConfigMaps (\`cbioagent-clone-sql-msk\`, \`cbioagent-study-guides-msk\`) with \`disableNameSuffixHash: true\` so downstream references remain stable.
- **Existing Application** \`portal-configuration\` (666 source) gets a one-line \`exclude: 'secrets/cbioagent/msk-configmaps/**'\` so it doesn't try to apply \`kustomization.yaml\` + raw \`.sql\` / \`.md\` files as plain manifests.

## Trade-off

Two Argo cards in the UI instead of one for portal-configuration's 666 deployment. In exchange the markdown renders properly on GitHub, the SQL is editable in any editor with syntax highlighting, and updating either no longer requires threading through YAML literal-block quoting.

## Dependencies

Merge **portal-configuration#20 first** so the Kustomize subdir exists in main when this Application tries to sync. Otherwise the new Application will report a sync error pointing at a missing path until #20 lands.

## Test plan

After both PRs merge + Argo syncs:
- [ ] \`cbioagent-msk-configmaps\` Application appears in Argo, status Healthy.
- [ ] \`kubectl get configmap cbioagent-clone-sql-msk cbioagent-study-guides-msk -o name\` returns both.
- [ ] \`kubectl get configmap cbioagent-clone-sql-msk -o jsonpath='{.data}' | jq 'keys'\` returns \`["4-msk-preferences.sql"]\`.
- [ ] \`kubectl get configmap cbioagent-study-guides-msk -o jsonpath='{.data}' | jq 'keys'\` returns \`["mskimpact.md"]\`.
- [ ] The portal-configuration Application's sync status remains Healthy and shows no extra resources from the excluded subdir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)