### PR TITLE
666: install stakater/reloader

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/reloader.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/reloader.yaml
@@ -1,0 +1,37 @@
+# Stakater Reloader — watches ConfigMaps and Secrets for changes and
+# auto-rolls Deployments/StatefulSets/DaemonSets that opt in via an
+# annotation. Lets us drop the rollout container in the cbioagent
+# clone CronJob: the cron just patches clickhouse-mcp-active, and
+# Reloader sees that and restarts cbioagent-clickhouse-mcp.
+#
+# Targeted annotation pattern (preferred over auto-mode):
+#   metadata.annotations.configmap.reloader.stakater.com/reload:
+#     "clickhouse-mcp-active"
+#
+# Refs:
+#   https://github.com/stakater/Reloader
+#   https://stakater.github.io/stakater-charts/index.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://stakater.github.io/stakater-charts
+    chart: reloader
+    targetRevision: 2.2.12
+    helm:
+      releaseName: reloader
+      # Defaults watch all namespaces, no leader election (single replica),
+      # no extra metrics. Override here if/when we need to scope it.
+  destination:
+    namespace: reloader
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Installs [stakater/reloader](https://github.com/stakater/Reloader) on the MSK (666) cluster via its official Helm chart (v2.2.12, appVersion 1.4.17). Watches ConfigMaps and Secrets for changes and auto-rolls Deployments that opt in via an annotation.

Enables dropping the rollout container in the cbioagent clone CronJob (PR #485 will be updated to do that) — the cron patches \`clickhouse-mcp-active\`, Reloader sees the change, MCP rolls automatically.

## Scope

666 only for now. 203 keeps its rollout-container pattern. If it works well here, 203 can adopt later as cleanup.

## Annotation pattern (added to MCP Deployment in companion PR)

\`\`\`yaml
metadata:
  annotations:
    configmap.reloader.stakater.com/reload: "clickhouse-mcp-active"
\`\`\`

Targeted form (specific configmap) rather than \`reloader.stakater.com/auto: "true"\` (any envFrom configmap change) — narrower blast radius.

## Test plan

After Argo sync:
- [ ] \`reloader\` Deployment running in \`reloader\` namespace
- [ ] After companion PR lands: editing \`clickhouse-mcp-active\` ConfigMap triggers a rollout of \`cbioagent-clickhouse-mcp\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)