### PR TITLE
cbioagent (msk): bump LibreChat to v0.8.3-rc1-custom-v9

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -18,7 +18,7 @@ image:
   registry: docker.io
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.8.3-rc1-custom-v5"
+  tag: "v0.8.3-rc1-custom-v9"
 
 mongodb:
   enabled: false


### PR DESCRIPTION
Matches the tag currently running on 203 (chat.cbioportal.org). 666 was 4 versions behind.