### PR TITLE
cbioagent (msk) mcp: mount general-guides ConfigMap

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -44,18 +44,26 @@ spec:
             - configMapRef:
                 name: clickhouse-mcp-active
           volumeMounts:
-            # MSK-private study guides (lives in portal-configuration).
-            # Overlays the image's baked-in study-guides directory while
-            # the container is running, so the MCP server's
-            # _load_study_guide(study_id) picks up MSK content (e.g.
+            # MSK study guides (lives in portal-configuration). Overlays
+            # the image's baked-in study-guides directory so the MCP's
+            # _load_study_guide(study_id) returns MSK content (e.g.
             # mskimpact.md) instead of the public-portal guides.
             - mountPath: /app/src/cbioportal_mcp/resources/study-guides
               name: study-guides
+              readOnly: true
+            # MSK general guides surfaced via the MCP's
+            # get_general_guide(name) tool — e.g. cdsi-info on CDSI data
+            # provenance.
+            - mountPath: /app/src/cbioportal_mcp/resources/guides
+              name: general-guides
               readOnly: true
       volumes:
         - name: study-guides
           configMap:
             name: cbioagent-study-guides-msk
+        - name: general-guides
+          configMap:
+            name: cbioagent-general-guides-msk
       nodeSelector:
         workload: "cbioagent"
       tolerations:


### PR DESCRIPTION
Second volume mount on `cbioagent-clickhouse-mcp` to overlay `cbioagent-general-guides-msk` onto `/app/src/cbioportal_mcp/resources/guides/`. Surfaces deployment-specific guides (`cdsi-info` initially) via the MCP's `get_general_guide(name)` tool.

Depends on:
- [cbioportal/cbioportal-mcp#74](https://github.com/cBioPortal/cbioportal-mcp/pull/74) — merged; `resources/guides/` dir + `get_general_guide` tool. Lands on the cluster on the next image pull (`imagePullPolicy: Always`; Reloader rolls on cron tick).
- [knowledgesystems/portal-configuration#26](https://github.com/knowledgesystems/portal-configuration/pull/26) — adds the Kustomize entry for `cbioagent-general-guides-msk`. Must merge before this PR's volume reference resolves.