### PR TITLE
Add cell-explorer deployment to cbioportal-prod

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cell-explorer.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cell-explorer.yaml
@@ -2,6 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cell-explorer
+  namespace: argocd
 spec:
   project: default
   source:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cell-explorer.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cell-explorer.yaml
@@ -11,10 +11,11 @@ spec:
     targetRevision: HEAD
     directory:
       recurse: true
+  # Manual sync — we bring cell-explorer up one resource at a time and sync by
+  # hand; no automated/selfHeal/prune.
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
   destination:
     namespace: cell-explorer
     server: https://kubernetes.default.svc

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cell-explorer.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/cell-explorer.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cell-explorer
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/knowledgesystems/knowledgesystems-k8s-deployment
+    path: argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer
+    targetRevision: HEAD
+    directory:
+      recurse: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: cell-explorer
+    server: https://kubernetes.default.svc

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
@@ -51,9 +51,11 @@ Bring it up in this order with `terraform`/`kubectl`, validating each step befor
 
 ### DNS
 
-Point `cell-explorer.cbioportal.org` at the cluster's nginx ingress load balancer
-(same target as other `*.cbioportal.org` apps). cert-manager issues the TLS cert
-automatically once DNS resolves.
+Point `cell-explorer.cbioportal.org` at the cluster's Traefik ingress load balancer
+(same ELB as other `*.cbioportal.org` apps). cert-manager issues the TLS cert
+automatically once DNS resolves and the ACME challenge can reach Traefik. The Ingress
+uses `ingressClassName`/annotation `traefik` (the cluster's active controller — nginx is
+not deployed).
 
 ### Seed the dataset catalog
 

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
@@ -1,0 +1,43 @@
+# cell-explorer
+
+Production deployment of [cell-explorer-py](https://github.com/cBioPortal/cell-explorer-py)
+on `cbioportal-prod`. Served at https://cell-explorer.cbioportal.org.
+
+Single-replica FastAPI app (serves API + frontend) on a dedicated `workload=cell-explorer`
+node, with an EBS-backed SQLite catalog at `/app/data`. Zarr datasets are fetched directly
+over HTTPS from the public cbioportal imaging bucket — no datasource signing is configured
+(all datasets are public).
+
+## One-time manual steps (not in git)
+
+### 1. Create the Secret
+
+Secret values are never committed. Create the Secret directly:
+
+```bash
+kubectl -n cell-explorer create secret generic cell-explorer-secrets \
+  --from-literal=KEYCLOAK_CLIENT_SECRET='<from keycloak cell-explorer realm>' \
+  --from-literal=ANTHROPIC_API_KEY='<anthropic key>' \
+  --from-literal=ADMIN_API_KEY='<generate: python -c "import secrets; print(secrets.token_urlsafe(32))">' \
+  --from-literal=CLI_STATE_SECRET='<generate: python -c "import secrets; print(secrets.token_urlsafe(32))">'
+# Optional Langfuse tracing: append --from-literal=LANGFUSE_PUBLIC_KEY=... etc.
+```
+
+### 2. DNS
+
+Point `cell-explorer.cbioportal.org` at the cluster's nginx ingress load balancer
+(same target as other `*.cbioportal.org` apps). cert-manager issues the TLS cert
+automatically once DNS resolves.
+
+### 3. Seed the dataset catalog
+
+Using `ADMIN_API_KEY`, create datasources/datasets via the admin API
+(`POST /api/admin/datasources`, `POST /api/admin/datasets`). Mark public datasets
+`is_public: true` so they serve without datasource credentials.
+
+## Notes
+- Image tag is pinned (not `latest`). Bump it here to deploy a new version.
+- `Recreate` deploy strategy: the RWO EBS volume can't be shared across pods, so the
+  old pod stops before the new one starts. Brief downtime on each deploy is expected.
+- Keycloak realm session timeouts gate re-login; cookie max-ages in `configmap.yaml`
+  must stay `<=` the realm's `ssoSessionMaxLifespan`.

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
@@ -8,20 +8,19 @@ node, with an EBS-backed SQLite catalog at `/app/data`. Zarr datasets are fetche
 over HTTPS from the public cbioportal imaging bucket — no datasource signing is configured
 (all datasets are public).
 
-## One-time manual steps (not in git)
+## One-time manual steps
 
-### 1. Create the Secret
+### 1. Secret
 
-Secret values are never committed. Create the Secret directly:
+The `cell-explorer-secrets` Secret is **not** in this repo — it lives in the private
+`portal-configuration` repo under `secrets/cell-explorer/` (cluster secrets convention).
+It must provide these keys, all consumed via `envFrom.secretRef` by the Deployment:
 
-```bash
-kubectl -n cell-explorer create secret generic cell-explorer-secrets \
-  --from-literal=KEYCLOAK_CLIENT_SECRET='<from keycloak cell-explorer realm>' \
-  --from-literal=ANTHROPIC_API_KEY='<anthropic key>' \
-  --from-literal=ADMIN_API_KEY='<generate: python -c "import secrets; print(secrets.token_urlsafe(32))">' \
-  --from-literal=CLI_STATE_SECRET='<generate: python -c "import secrets; print(secrets.token_urlsafe(32))">'
-# Optional Langfuse tracing: append --from-literal=LANGFUSE_PUBLIC_KEY=... etc.
-```
+- `KEYCLOAK_CLIENT_SECRET` — from the Keycloak `cell-explorer` realm
+- `ANTHROPIC_API_KEY` — chat agent
+- `ADMIN_API_KEY` — admin API (generate: `python -c "import secrets; print(secrets.token_urlsafe(32))"`)
+- `CLI_STATE_SECRET` — CLI auth (generate the same way)
+- optional Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`
 
 ### 2. DNS
 

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
@@ -4,16 +4,20 @@ Production deployment of [cell-explorer-py](https://github.com/cBioPortal/cell-e
 on `cbioportal-prod`. Served at https://cell-explorer.cbioportal.org.
 
 Single-replica FastAPI app (serves API + frontend) on a dedicated `workload=cell-explorer`
-node, with an EBS-backed SQLite catalog at `/app/data`. Zarr datasets are fetched directly
-over HTTPS from the public cbioportal imaging bucket — no datasource signing is configured
-(all datasets are public).
+spot nodegroup (2 nodes), with an EBS-backed SQLite catalog at `/app/data`. Zarr datasets
+are fetched directly over HTTPS from the public cbioportal imaging bucket — no datasource
+signing is configured (all datasets are public).
+
+This app is brought up **manually, one resource at a time** (see Rollout), and its ArgoCD
+Application is **manual-sync** (no automated/selfHeal/prune).
 
 ## Configuration (lives in `portal-configuration`)
 
 The Deployment loads **all** runtime config via `envFrom` — a ConfigMap and a Secret that
 are **not** in this repo. Both live in the private `portal-configuration` repo under
-`argocd/aws/203403084713/clusters/cbioportal-prod/` and are applied automatically by the
-`portal-configuration` ArgoCD Application (no Application changes needed here):
+`argocd/aws/203403084713/clusters/cbioportal-prod/` (`configmaps/` and `secrets/cell-explorer/`).
+During the manual bring-up below, apply them by hand; ongoing, the `portal-configuration`
+ArgoCD Application reconciles them:
 
 - **ConfigMap `cell-explorer-config`** — `configmaps/cell-explorer-configmap.yaml`
   (non-secret env: `ENVIRONMENT`, Keycloak URL/realm/client, CORS, `ZARR_ACCESS_ORIGIN`,
@@ -29,15 +33,29 @@ Both set `namespace: cell-explorer`, so until this app creates that namespace th
 error-then-self-heal on the `portal-configuration` Application. The pod stays in
 `CreateContainerConfigError` until both exist.
 
-## One-time manual steps
+## Rollout (manual, one resource at a time)
 
-### 1. DNS
+Bring it up in this order with `terraform`/`kubectl`, validating each step before the next:
+
+1. **Nodegroup** — `terraform apply` in `iac/.../cbioportal-prod/eks` to create the
+   `cell-explorer` spot nodegroup; wait for 2 nodes `Ready`.
+2. **Namespace** — `kubectl apply -f namespace.yaml`.
+3. **Config + Secret** — apply the ConfigMap and Secret from `portal-configuration`
+   (`configmaps/cell-explorer-configmap.yaml`, `secrets/cell-explorer/cell-explorer-secrets.yaml`).
+4. **PVC** — `kubectl apply -f pvc.yaml` (binds once the Deployment pod schedules).
+5. **Deployment + Service** — `kubectl apply -f deployment.yaml`; watch the pod reach
+   `Ready` (`/health`). It stays in `CreateContainerConfigError` until step 3 exists.
+6. **Ingress** — `kubectl apply -f ingress.yaml`.
+7. **ArgoCD** — once validated, sync the manual-sync `cell-explorer` Application to bring
+   everything under GitOps. It will not auto-sync; sync by hand.
+
+### DNS
 
 Point `cell-explorer.cbioportal.org` at the cluster's nginx ingress load balancer
 (same target as other `*.cbioportal.org` apps). cert-manager issues the TLS cert
 automatically once DNS resolves.
 
-### 2. Seed the dataset catalog
+### Seed the dataset catalog
 
 Using `ADMIN_API_KEY`, create datasources/datasets via the admin API
 (`POST /api/admin/datasources`, `POST /api/admin/datasets`). Mark public datasets
@@ -45,6 +63,9 @@ Using `ADMIN_API_KEY`, create datasources/datasets via the admin API
 
 ## Notes
 - Image tag is pinned (not `latest`). Bump it here to deploy a new version.
+- Spot nodegroup (2 nodes, single AZ): on a spot interruption the pod reschedules onto the
+  other node and the EBS volume reattaches in the same AZ. Instance types are diversified
+  (`m7i`/`m6i`/`m5` large) so the ASG can find spot capacity.
 - `Recreate` deploy strategy: the RWO EBS volume can't be shared across pods, so the
   old pod stops before the new one starts. Brief downtime on each deploy is expected.
 - Keycloak realm session timeouts gate re-login; keep the cookie max-ages in the

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/README.md
@@ -8,27 +8,36 @@ node, with an EBS-backed SQLite catalog at `/app/data`. Zarr datasets are fetche
 over HTTPS from the public cbioportal imaging bucket — no datasource signing is configured
 (all datasets are public).
 
+## Configuration (lives in `portal-configuration`)
+
+The Deployment loads **all** runtime config via `envFrom` — a ConfigMap and a Secret that
+are **not** in this repo. Both live in the private `portal-configuration` repo under
+`argocd/aws/203403084713/clusters/cbioportal-prod/` and are applied automatically by the
+`portal-configuration` ArgoCD Application (no Application changes needed here):
+
+- **ConfigMap `cell-explorer-config`** — `configmaps/cell-explorer-configmap.yaml`
+  (non-secret env: `ENVIRONMENT`, Keycloak URL/realm/client, CORS, `ZARR_ACCESS_ORIGIN`,
+  cookie max-ages).
+- **Secret `cell-explorer-secrets`** — `secrets/cell-explorer/cell-explorer-secrets.yaml`:
+  - `KEYCLOAK_CLIENT_SECRET` — from the Keycloak `cell-explorer` realm
+  - `ANTHROPIC_API_KEY` — chat agent
+  - `ADMIN_API_KEY` — admin API (generate: `python -c "import secrets; print(secrets.token_urlsafe(32))"`)
+  - `CLI_STATE_SECRET` — CLI auth (generate the same way)
+  - optional Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`
+
+Both set `namespace: cell-explorer`, so until this app creates that namespace they
+error-then-self-heal on the `portal-configuration` Application. The pod stays in
+`CreateContainerConfigError` until both exist.
+
 ## One-time manual steps
 
-### 1. Secret
-
-The `cell-explorer-secrets` Secret is **not** in this repo — it lives in the private
-`portal-configuration` repo under `secrets/cell-explorer/` (cluster secrets convention).
-It must provide these keys, all consumed via `envFrom.secretRef` by the Deployment:
-
-- `KEYCLOAK_CLIENT_SECRET` — from the Keycloak `cell-explorer` realm
-- `ANTHROPIC_API_KEY` — chat agent
-- `ADMIN_API_KEY` — admin API (generate: `python -c "import secrets; print(secrets.token_urlsafe(32))"`)
-- `CLI_STATE_SECRET` — CLI auth (generate the same way)
-- optional Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`
-
-### 2. DNS
+### 1. DNS
 
 Point `cell-explorer.cbioportal.org` at the cluster's nginx ingress load balancer
 (same target as other `*.cbioportal.org` apps). cert-manager issues the TLS cert
 automatically once DNS resolves.
 
-### 3. Seed the dataset catalog
+### 2. Seed the dataset catalog
 
 Using `ADMIN_API_KEY`, create datasources/datasets via the admin API
 (`POST /api/admin/datasources`, `POST /api/admin/datasets`). Mark public datasets
@@ -38,5 +47,6 @@ Using `ADMIN_API_KEY`, create datasources/datasets via the admin API
 - Image tag is pinned (not `latest`). Bump it here to deploy a new version.
 - `Recreate` deploy strategy: the RWO EBS volume can't be shared across pods, so the
   old pod stops before the new one starts. Brief downtime on each deploy is expected.
-- Keycloak realm session timeouts gate re-login; cookie max-ages in `configmap.yaml`
-  must stay `<=` the realm's `ssoSessionMaxLifespan`.
+- Keycloak realm session timeouts gate re-login; keep the cookie max-ages in the
+  `cell-explorer-config` ConfigMap (in `portal-configuration`) `<=` the realm's
+  `ssoSessionMaxLifespan`.

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cell-explorer
+  namespace: cell-explorer
+  labels:
+    app: cell-explorer
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: cell-explorer
+  template:
+    metadata:
+      labels:
+        app: cell-explorer
+    spec:
+      nodeSelector:
+        workload: cell-explorer
+      tolerations:
+        - key: "workload"
+          operator: "Equal"
+          value: "cell-explorer"
+          effect: "NoSchedule"
+      containers:
+        - name: cell-explorer
+          image: ghcr.io/cbioportal/cell-explorer-py:0.2.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: cell-explorer-config
+            - secretRef:
+                name: cell-explorer-secrets
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: cell-explorer-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cell-explorer
+  namespace: cell-explorer
+spec:
+  selector:
+    app: cell-explorer
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+  type: ClusterIP

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -38,6 +38,14 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+          # Alembic migrations run before uvicorn serves /health; give a slow
+          # first-boot migration up to 5min before liveness/readiness apply.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /health

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/ingress.yaml
@@ -5,28 +5,23 @@ metadata:
   namespace: cell-explorer
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: traefik
     kubernetes.io/tls-acme: "true"
-    ingress.kubernetes.io/proxy-body-size: 512m
-    nginx.ingress.kubernetes.io/proxy-body-size: 512m
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+  labels:
+    app.kubernetes.io/instance: cell-explorer
 spec:
   rules:
     - host: cell-explorer.cbioportal.org
       http:
         paths:
-          - backend:
+          - path: /
+            pathType: Prefix
+            backend:
               service:
                 name: cell-explorer
                 port:
                   number: 8000
-            path: /
-            pathType: Prefix
   tls:
     - hosts:
         - cell-explorer.cbioportal.org
-      secretName: cell-explorer-cbioportal
+      secretName: cell-explorer-cbioportal-cert

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cell-explorer-ingress
+  namespace: cell-explorer
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    ingress.kubernetes.io/proxy-body-size: 512m
+    nginx.ingress.kubernetes.io/proxy-body-size: 512m
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+spec:
+  rules:
+    - host: cell-explorer.cbioportal.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: cell-explorer
+                port:
+                  number: 8000
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - cell-explorer.cbioportal.org
+      secretName: cell-explorer-cbioportal

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/namespace.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cell-explorer

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/pvc.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cell-explorer-data
+  namespace: cell-explorer
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 10Gi

--- a/iac/aws/203403084713/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/203403084713/clusters/cbioportal-prod/eks/main.tf
@@ -332,7 +332,10 @@ locals {
         (var.LABEL_KEY) = "cbio-api"
       }
     }
-    cell-explorer = {
+    # Nodegroup name kept <=12 chars: the module derives an IAM role name_prefix
+    # "userServiceRole-<name>-<hash>-" which AWS caps at 38. Workload taint/label
+    # below stay "cell-explorer" to match the Deployment's nodeSelector.
+    cellexplorer = {
       instance_types = ["m7i.large", "m6i.large", "m5.large"]
       capacity_type  = "SPOT"
       ami_type       = "BOTTLEROCKET_x86_64"

--- a/iac/aws/203403084713/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/203403084713/clusters/cbioportal-prod/eks/main.tf
@@ -333,12 +333,14 @@ locals {
       }
     }
     cell-explorer = {
-      instance_types = ["m7i.large"]
+      instance_types = ["m7i.large", "m6i.large", "m5.large"]
+      capacity_type  = "SPOT"
       ami_type       = "BOTTLEROCKET_x86_64"
-      desired_size   = 1
-      min_size       = 1
-      max_size       = 1
-      # Pin to a single subnet/AZ so the EBS-backed PVC always reattaches.
+      desired_size   = 2
+      min_size       = 2
+      max_size       = 2
+      # Single subnet/AZ so the EBS-backed PVC reattaches when a spot
+      # interruption reschedules the pod onto the other node.
       subnet_ids = ["subnet-066aca23688737c91"]
       taints = {
         dedicated = {

--- a/iac/aws/203403084713/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/203403084713/clusters/cbioportal-prod/eks/main.tf
@@ -332,6 +332,30 @@ locals {
         (var.LABEL_KEY) = "cbio-api"
       }
     }
+    cell-explorer = {
+      instance_types = ["m7i.large"]
+      ami_type       = "BOTTLEROCKET_x86_64"
+      desired_size   = 1
+      min_size       = 1
+      max_size       = 1
+      # Pin to a single subnet/AZ so the EBS-backed PVC always reattaches.
+      subnet_ids = ["subnet-066aca23688737c91"]
+      taints = {
+        dedicated = {
+          key    = var.TAINT_KEY
+          value  = "cell-explorer"
+          effect = var.TAINT_EFFECT
+        }
+      }
+      labels = {
+        (var.LABEL_KEY) = "cell-explorer"
+      }
+      tags = {
+        cdsi-app   = "cell-explorer"
+        cdsi-team  = "data-visualization"
+        cdsi-owner = "hweej@mskcc.org"
+      }
+    }
   }
 
   karpenter_discovery_tag_value = var.CLUSTER_NAME
@@ -397,7 +421,7 @@ resource "kubernetes_storage_class_v1" "ebs-storage-class-default" {
   allow_volume_expansion = true
 
   parameters = {
-    type      = "gp3"
+    type = "gp3"
   }
 }
 


### PR DESCRIPTION
## Summary
Deploys [cell-explorer-py](https://github.com/cBioPortal/cell-explorer-py) at https://cell-explorer.cbioportal.org on `cbioportal-prod`, via the ArgoCD app-of-apps.

- New ArgoCD `Application` + app manifests: Namespace, EBS PVC (`ebs-sc`, RWO, 10Gi), ConfigMap, Deployment + ClusterIP Service (1 replica, `Recreate`, image pinned `ghcr.io/cbioportal/cell-explorer-py:0.2.0`), nginx Ingress with cert-manager TLS.
- New dedicated EKS managed nodegroup `cell-explorer` (`m7i.large`, `BOTTLEROCKET_x86_64`, 1/1/1), pinned to a single subnet/AZ so the EBS-backed SQLite volume always reattaches.
- Single replica + EBS RWO because the catalog is single-writer SQLite at `/app/data`.
- `startupProbe` gives the first-boot Alembic migration up to 5min before liveness/readiness apply.

## Notes
- Datasets are public, fetched directly over HTTPS from the cbioportal imaging bucket — no S3/IAM/CloudFront or datasource signing in scope.
- The `cell-explorer-secrets` Secret is not in this repo; it lives in `portal-configuration/secrets/cell-explorer/` (see app README).

## Rollout (post-merge, manual — needs AWS/cluster creds)
- [ ] `terraform apply` the new nodegroup
- [ ] Add the Secret to `portal-configuration/secrets/cell-explorer/`
- [ ] ArgoCD sync; confirm pod `Running` + `/health` green
- [ ] Point DNS `cell-explorer.cbioportal.org` at the nginx ingress LB (cert-manager issues TLS)
- [ ] Seed the dataset catalog via the admin API