### PR TITLE
cbioagent librechat-config: use Lucide kebab names for starter icons

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -172,14 +172,14 @@ data:
                 - "How many studies have whole exome sequencing data?"
                 - "What TCGA data do you have?"
             - label: "Navigate cBioPortal"
-              icon: "map"
+              icon: "map-pin"
               description: "Create direct links to cBioPortal views, cohorts, plots, and study pages."
               starters:
                 - "Give me an OncoPrint for EGFR and KRAS in TCGA lung adenocarcinoma."
                 - "Can you create a cohort of metastatic prostate cancer with AR amplification?"
                 - "Show me a KM plot of primary vs met prostate cancer in the MSK-IMPACT study."
             - label: "Analyze Data"
-              icon: "heartbeat"
+              icon: "heart-pulse"
               description: "Compare genes, cancer types, molecular profiles, cohorts, and outcomes."
               starters:
                 - "Show me TP53 mutation frequency across all cancer types."


### PR DESCRIPTION
Aligns 203's cbioagent (chat.cbioportal.org) with [cbioportal/LibreChat#20](https://github.com/cBioPortal/LibreChat/pull/20) which replaces the hardcoded 6-name alias table with a Lucide namespace lookup.

Preserves current visuals:
- `map` → `map-pin` (pin icon, used on Navigate cBioPortal)
- `heartbeat` → `heart-pulse` (Analyze Data)
- `search` unchanged

### Don't merge yet

Merging before the new LibreChat image (containing #20) is deployed will fall back to the search icon for both buckets. Sequence:

1. Merge cbioportal/LibreChat#20
2. New image (v10) gets built + pushed
3. Bump `tag` in `apps/cbioagent/values.yaml` to that image
4. Merge this PR

Companion: [portal-configuration#30](https://github.com/knowledgesystems/portal-configuration/pull/30) does the same for 666.