### PR TITLE
cbioagent (666): use Reloader for the LibreChat rollout

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/cbioagent.yaml
@@ -13,7 +13,7 @@ spec:
       ref: k8s-repo
     - chart: librechat
       repoURL: ghcr.io/danny-avila/librechat-chart
-      targetRevision: 1.9.1
+      targetRevision: 1.9.8
       helm:
         releaseName: cbioagent
         valueFiles:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -6,6 +6,10 @@ global:
   imagePullSecrets:
     - dockerhub-creds
 
+deploymentAnnotations:
+  configmap.reloader.stakater.com/reload: "librechat-config"
+  secret.reloader.stakater.com/reload: "librechat-credentials-env"
+
 librechat:
   existingSecretName: "librechat-credentials-env"
   existingConfigYaml: "librechat-config"


### PR DESCRIPTION
## Summary

- Add \`deploymentAnnotations\` so Stakater Reloader restarts the LibreChat Deployment on 666 when \`librechat-config\` (ConfigMap) or \`librechat-credentials-env\` (Secret) change.
- Bump the upstream LibreChat chart from 1.9.1 → 1.9.8 to match 203 (where this exact pattern has been driving rollouts for ~2 weeks).

## Why

Today the MSK chat (\`chat.cbioportal.aws.mskcc.org\`) was still rendering the old fallback (looking-glass) icon for the \"Analyze Data\" starter category. \`librechat-config\` says \`icon: heart-pulse\`, which today's v9 builds resolve to \`HeartPulse\`, but the running pod is on an older v9 layer that predates the kebab→PascalCase resolver — so the lookup fell through to \`Search\`.

The root cause is that 666 has no rollout signal wired to its config: a librechat-config edit only takes effect on the next manual \`kubectl rollout restart\`. With this PR, any future ConfigMap/Secret edit (and any new image pushed to the mutable \`v0.8.3-rc1-custom-v9\` tag, indirectly via Reloader-triggered pull) cycles the pod automatically — same as 203.

## Test plan

- [ ] Argo syncs without diff errors
- [ ] After sync, \`kubectl --context=cbioagent-msk get deploy/cbioagent-librechat -o yaml | grep reloader\` shows the two annotations on the Deployment metadata
- [ ] LibreChat pod restarts as part of the sync (since the chart bump + annotation add changes the spec)
- [ ] Pod pulls the current \`v0.8.3-rc1-custom-v9\` digest
- [ ] \"Analyze Data\" category on chat.cbioportal.aws.mskcc.org renders HeartPulse instead of the magnifying glass

🤖 Generated with [Claude Code](https://claude.com/claude-code)