### PR TITLE
cbioagent-mcp: set CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS=* (203 + 666)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -45,6 +45,15 @@ spec:
             # middleware on the mcp-cbioportal-db-ingress Ingress.
             - name: CLICKHOUSE_MCP_HTTP_PATH
               value: "/db/mcp"
+            # Trust X-Forwarded-* from any in-cluster source so uvicorn's
+            # 307 trailing-slash redirect honors Traefik's
+            # X-Forwarded-Proto: https. Without this the Location
+            # downgrades to http:// and strict clients (Claude Desktop,
+            # etc.) refuse to follow. The listener is only reachable via
+            # in-cluster Services (Traefik on the public path,
+            # cbioagent-librechat on the internal path), so "*" is fine.
+            - name: CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS
+              value: "*"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -33,6 +33,14 @@ spec:
             # full external path.
             - name: CLICKHOUSE_MCP_HTTP_PATH
               value: "/db/mcp"
+            # Trust X-Forwarded-* from any in-cluster source so uvicorn's
+            # 307 trailing-slash redirect honors Traefik's
+            # X-Forwarded-Proto: https. Without this the Location
+            # downgrades to http:// and strict clients (Claude Desktop,
+            # etc.) refuse to follow. The listener is only reachable via
+            # in-cluster Services, so "*" is fine.
+            - name: CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS
+              value: "*"
           envFrom:
             - secretRef:
                 name: clickhouse-mcp


### PR DESCRIPTION
## Summary

Set \`CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS=*\` on the cbioagent-clickhouse-mcp Deployment in both 203 and 666. Pairs with cbioportal/cbioportal-mcp#78 (already merged) — without this env, the new MCP image keeps uvicorn's default (no \`proxy_headers\`, only 127.0.0.1 trusted) and the bug below remains.

## Why

The public DB MCP at \`https://mcp.cbioportal.org/db/mcp\` is reached through Traefik, which terminates TLS and forwards over plain http. Starlette's \`Mount\` returns a 307 to add the trailing slash. Without \`proxy_headers\`, uvicorn ignores \`X-Forwarded-Proto: https\` and builds the redirect Location from its own scheme:

\`\`\`
location: http://mcp.cbioportal.org/db/mcp/   ← scheme downgrade
\`\`\`

Strict clients (Claude Desktop in particular) refuse the downgrade and bail with "Couldn't connect."

Setting the env to \`*\` enables \`proxy_headers\` and trusts any upstream's X-Forwarded-* headers. Safe in this topology: the listener is only reachable via in-cluster Services (Traefik on the public path, cbioagent-librechat on the internal path) — no direct external pod access.

## Test plan

- [ ] After Argo sync + Reloader rollout: \`curl -sI https://mcp.cbioportal.org/db/mcp\` returns \`Location: https://...\` (not http).
- [ ] Claude Desktop connects to \`https://mcp.cbioportal.org/db/mcp\` and lists DB MCP tools.
- [ ] LibreChat's existing in-cluster MCP calls still work (no behavior change for them — they don't send X-Forwarded-Proto).
- [ ] Same checks on 666 against \`https://chat.cbioportal.aws.mskcc.org/db/mcp\` (or whichever public hostname the MSK ingress uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)