### PR TITLE
cbioagent-db-ingress (666): route OAuth well-known paths to MCP

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -41,3 +41,29 @@ spec:
                 name: cbioagent-clickhouse-mcp
                 port:
                   number: 80
+          # Route OAuth discovery paths to the MCP backend so they 404
+          # cleanly. Without these, nginx falls through to the LibreChat
+          # SPA's catch-all at `/`, which serves index.html (200 OK,
+          # text/html). Claude Desktop interprets the 200 as "OAuth is
+          # required here" and tries Dynamic Client Registration, which
+          # fails ("Couldn't register with cBioPortal MSK DB's sign-in
+          # service"). FastMCP returns 404 for any path outside /db/mcp,
+          # which is the correct signal for "no OAuth required" — the
+          # client then connects unauthenticated.
+          #
+          # 203 doesn't need this because mcp.cbioportal.org is a
+          # dedicated subdomain — no LibreChat SPA collision.
+          - path: /.well-known/oauth-protected-resource
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp
+                port:
+                  number: 80
+          - path: /.well-known/oauth-authorization-server
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp
+                port:
+                  number: 80


### PR DESCRIPTION
## Why

\`chat.cbioportal.aws.mskcc.org\` hosts both LibreChat (at \`/\`) and the DB MCP (at \`/db/mcp\`). LibreChat's SPA serves \`index.html\` (200 OK, text/html) for **any** path under \`/\` it doesn't recognize, including \`/.well-known/oauth-protected-resource\` and \`/.well-known/oauth-authorization-server\`.

Claude Desktop probes those well-known paths when setting up an MCP connection. Getting a 200 with HTML, it concludes "OAuth is required here", tries Dynamic Client Registration against the HTML response, and fails with:

> Couldn't register with cBioPortal MSK DB's sign-in service. You can try again, or add an OAuth Client ID in the connector settings.

Confirmed by probing from inside the cluster:

\`\`\`
GET chat.cbioportal.aws.mskcc.org/.well-known/oauth-protected-resource
  via ingress:        200 OK, text/html, 4914 bytes   (LibreChat index.html)
  routed to MCP:      404 Not Found                    (correct)
\`\`\`

## Fix

Add explicit path rules for both well-known OAuth endpoints on \`cbioagent-db-ingress\`, routing them to the MCP service. FastMCP 404s any path outside \`/db/mcp\` — and a 404 is the correct signal to clients that no OAuth is needed. Claude Desktop then proceeds to connect unauthenticated.

## Why 203 doesn't need this

\`mcp.cbioportal.org\` is a dedicated subdomain on 203 — no LibreChat SPA there, so well-known paths already 404 via Traefik's default behavior.

## Test plan

- [ ] After Argo sync: \`curl -sI https://chat.cbioportal.aws.mskcc.org/.well-known/oauth-protected-resource\` returns 404 from uvicorn (not 200 from LibreChat).
- [ ] Same for \`/.well-known/oauth-authorization-server\`.
- [ ] Claude Desktop connects to \`https://chat.cbioportal.aws.mskcc.org/db/mcp\` and lists the DB MCP tools.
- [ ] LibreChat itself still loads at \`https://chat.cbioportal.aws.mskcc.org/\` (longest-prefix match means \`/\` keeps LibreChat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)