### PR TITLE
cbioagent-db-ingress (666): pathType ImplementationSpecific for well-known paths

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -53,15 +53,21 @@ spec:
           #
           # 203 doesn't need this because mcp.cbioportal.org is a
           # dedicated subdomain — no LibreChat SPA collision.
+          # pathType: ImplementationSpecific — nginx-ingress's admission
+          # webhook rejects `pathType: Prefix` for paths containing dots
+          # (treated as regex meta-characters under strict validation).
+          # ImplementationSpecific delegates path matching to the
+          # controller, which handles the literal `.well-known` segment
+          # as a normal prefix.
           - path: /.well-known/oauth-protected-resource
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: cbioagent-clickhouse-mcp
                 port:
                   number: 80
           - path: /.well-known/oauth-authorization-server
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: cbioagent-clickhouse-mcp


### PR DESCRIPTION
Follow-up to #500.

The well-known paths PR #500 added were rejected at apply-time by nginx-ingress's strict-validation admission webhook:

\`\`\`
admission webhook \"validate.nginx.ingress.kubernetes.io\" denied the request:
  ingress contains invalid paths: path /.well-known/oauth-protected-resource
  cannot be used with pathType Prefix
\`\`\`

nginx-ingress treats \`.\` as a regex meta-character and refuses any path containing one under \`pathType: Prefix\` or \`Exact\`. Switching the two new paths to \`pathType: ImplementationSpecific\` delegates matching to the controller, which handles \`.well-known\` as a normal literal prefix — same routing behavior, just past the validator.

Argo's been retrying since #500 merged; the parent app \`cbioagent\` is OutOfSync with the message above and the new paths haven't taken effect yet. This unblocks the apply.

## Test plan

- [ ] After Argo sync, \`kubectl get ingress cbioagent-db-ingress\` shows three paths: \`/db\`, \`/.well-known/oauth-protected-resource\`, \`/.well-known/oauth-authorization-server\`.
- [ ] \`curl -sI https://chat.cbioportal.aws.mskcc.org/.well-known/oauth-protected-resource\` returns 404 from uvicorn (not 200 from LibreChat).
- [ ] Claude Desktop connects to \`https://chat.cbioportal.aws.mskcc.org/db/mcp\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)