### PR TITLE
cbioagent (203) librechat-config: suppress the LibreChat footer

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -20,14 +20,15 @@ data:
     # Custom interface configuration
     interface:
       customWelcome: "Hey {{user.name}}! Welcome to cBioPortalChat — explore cBioPortal data with natural language."
+      # Empty string suppresses LibreChat's default "LibreChat vX.X.X -
+      # Every AI for Everyone." footer string. Combined with omitting
+      # privacyPolicy below, the chat footer renders empty.
+      customFooter: ""
       remoteAgents:
         use: true
         create: true
       mcpServers:
         placeholder: 'MCP Servers'
-      privacyPolicy:
-        externalUrl: 'https://librechat.ai/privacy-policy'
-        openNewTab: true
       termsOfService:
         externalUrl: 'https://librechat.ai/tos'
         openNewTab: true


### PR DESCRIPTION
The chat footer currently renders:

> LibreChat v0.8.3-rc1 - Every AI for Everyone. | Privacy policy

The text is upstream branding and the privacy link points to \`librechat.ai/privacy-policy\` (we'd inherited it from the example config).

## Change

- Set \`interface.customFooter: \"\"\` — the upstream \`Footer.tsx\` short-circuits its default \"LibreChat … Every AI for Everyone.\" string when \`customFooter\` is any string, including empty.
- Drop the \`privacyPolicy\` block — the link only shows when \`externalUrl\` is set; removing the block hides it on both the chat page and the auth page.
- \`termsOfService\` is left intact — it drives the first-login acceptance modal, not anything in the footer.

Reloader is wired on the LibreChat Deployment on 203, so merge → Argo sync → pod restart will pick this up.

## Test plan

- [ ] After Argo sync: \`curl -s https://chat.cbioportal.org/api/config | jq '.customFooter, .interface.privacyPolicy'\` returns \`\"\"\` and \`null\`.
- [ ] chat.cbioportal.org renders no footer text below the chat input.
- [ ] Auth page (/login) doesn't show the privacy-policy link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)