### PR TITLE
cbioagent-beta (203): autodeploy from cbioportal/librechat beta branch via Keel

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/keel.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/argocd/keel.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keel
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/knowledgesystems/knowledgesystems-k8s-deployment
+      path: argocd/aws/203403084713/clusters/cbioportal-prod/apps/keel
+      targetRevision: HEAD
+      directory:
+        recurse: true
+      ref: k8s
+    - repoURL: https://charts.keel.sh
+      targetRevision: 1.2.0
+      chart: keel
+      helm:
+        releaseName: keel
+        valueFiles:
+          - $k8s/argocd/aws/203403084713/clusters/cbioportal-prod/apps/keel/values.yaml
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -19,6 +19,15 @@ replicaCount: 1
 deploymentAnnotations:
   secret.reloader.stakater.com/reload: "k8s-aws-creds-manager,librechat-credentials-env"
   configmap.reloader.stakater.com/reload: "librechat-config-beta"
+  # Beta tracks the mutable `cbioportal/librechat:beta` tag — every push
+  # to the `beta` branch on cbioportal/librechat overwrites that tag.
+  # Keel polls Docker Hub and rolls this Deployment when the digest
+  # behind `:beta` changes. policy=force matches any digest update;
+  # trigger=poll uses the default schedule (1 min) — fast enough for
+  # beta iteration without hammering the registry.
+  keel.sh/policy: force
+  keel.sh/trigger: poll
+  keel.sh/match-tag: "true"
 
 global:
   librechat:
@@ -56,14 +65,12 @@ image:
   repository: cbioportal/librechat
   registry: docker.io
   pullPolicy: Always
-  # Beta runs ahead of prod to validate dep/lib bumps before promotion.
-  # v9 = v8 + merge of cBioPortal/LibreChat#14 (unified UI config), with
-  # the v6/v7 "Switch Agent" landing-page button and agent-selector
-  # tooltip header dropped (no longer needed now that cBioAgent ships a
-  # single unified agent). UI behaviors that used to live in code are
-  # now expressed via librechat.yaml (`interface.showSwitchAgent`,
-  # modelSpec `limitBadge` / `conversationStarterCategories`, etc.).
-  tag: "v0.8.3-rc1-custom-v9"
+  # Beta follows the `beta` branch on cbioportal/librechat. The build
+  # workflow on that repo rebuilds and overwrites this mutable tag on
+  # every push, and Keel (see deploymentAnnotations above) rolls this
+  # pod when the digest behind the tag changes. Prod stays pinned to
+  # immutable v0.8.3-rc1-custom-vN tags so beta drift can't reach it.
+  tag: "beta"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/keel/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/keel/values.yaml
@@ -1,0 +1,39 @@
+# Keel watches container registries for tag content changes and rolls
+# the Deployments/StatefulSets annotated with `keel.sh/*` keys.
+#
+# Right now the only consumer is `cbioagent-librechat-beta`, which uses
+# the mutable `cbioportal/librechat:beta` tag — the build workflow on
+# cbioportal/librechat overwrites that tag on every push to the `beta`
+# branch, and Keel polls Docker Hub and rolls the beta Deployment when
+# the digest behind the tag changes.
+#
+# Prod (`cbioagent-librechat`) intentionally pins immutable
+# `v0.8.3-rc1-custom-vN` tags and is NOT annotated for Keel — promotion
+# from beta to prod stays a deliberate values.yaml bump + Argo sync.
+
+# No webhooks — public Docker Hub polling only. The default poll
+# interval is 1 minute, can be overridden per-Deployment via
+# `keel.sh/pollSchedule`.
+helmProvider:
+  enabled: false
+googleApplicationCredentials: ""
+notificationLevel: info
+
+# No external triggers; Keel only acts via Deployment annotations.
+webhookRelay:
+  enabled: false
+basicauth:
+  enabled: false
+
+rbac:
+  enabled: true
+serviceAccount:
+  create: true
+  name: keel
+
+# Cluster-wide watch so any annotated Deployment in any namespace works.
+# Cheap — Keel only polls images it sees annotations for.
+
+global:
+  imagePullSecrets:
+    - 'dockerhub-creds'


### PR DESCRIPTION
## What

Wire up continuous-deploy for \`beta.chat.cbioportal.org\`:

\`\`\`
push to cbioportal/librechat:beta
  → cbio-build.yml wildcard builds cbioportal/librechat:beta
  → Keel polls Docker Hub, sees a new digest behind the :beta tag
  → Keel triggers a rolling restart on cbioagent-librechat-beta
  → imagePullPolicy: Always pulls the new digest on the new pod
\`\`\`

The cbioportal/librechat \`beta\` branch was just cut from the v0.8.3-rc1-custom-v9 HEAD, and the existing \`.github/workflows/cbio-build.yml\` workflow already builds every branch and tags the image with the branch name, so on first push to that branch CI produces \`cbioportal/librechat:beta\` without any workflow change.

## Three changes here

1. **New Argo App \`keel\`** rendered from \`charts.keel.sh\` 1.2.0. Minimal values — cluster-wide watch, no webhooks, no helm-provider, \`dockerhub-creds\` for image-pull. Auto-sync on for self-heal parity with reloader.

2. **Beta \`values.yaml\` tag flip** from immutable \`v0.8.3-rc1-custom-v9\` to mutable \`beta\`.

3. **Beta \`deploymentAnnotations\`** get the Keel triggers (\`policy: force\`, \`trigger: poll\`, \`match-tag: \"true\"\`) alongside the existing Reloader annotations. Reloader still handles configmap + secret changes; Keel handles image-content changes.

## Prod is unaffected

\`cbioagent-librechat\` (prod) keeps the immutable \`v0.8.3-rc1-custom-vN\` tag and has NO Keel annotations — promotion to prod stays a deliberate values bump + Argo sync, never an auto-deploy.

## Test plan

- [ ] Argo syncs the new \`keel\` Application without errors; \`kubectl get pod -l app=keel\` shows a Running pod.
- [ ] After Argo syncs the beta values diff, \`kubectl describe deploy cbioagent-librechat-beta\` shows the three new annotations and image \`cbioportal/librechat:beta\`.
- [ ] First push to the beta branch on cbioportal/librechat → CI builds \`:beta\` → within ~1 min the beta pod restarts and reports the new image digest.
- [ ] Prod (\`cbioagent-librechat\`) is unchanged: same v9 image, no Keel annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)