### PR TITLE
cbioagent-beta (203): enable BYOK provider keys

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -120,6 +120,34 @@ data:
         disableBuilder: false
       assistants:
         disableBuilder: true
+      # BYOK custom endpoints. Paired with `*_API_KEY=user_provided`
+      # entries in apps/cbioagent-beta/values.yaml. The standard
+      # endpoints (anthropic / openAI / google / azureOpenAI) are
+      # registered by their env vars alone and don't need a yaml block.
+      # `apiKey: "user_provided"` is the hook that PR
+      # cbioportal/librechat#26 keys off to surface the per-provider
+      # BYOK input field under Settings → Data.
+      # `models.fetch: true` pulls the live model list from each
+      # provider's /models endpoint instead of pinning it here.
+      custom:
+        - name: "OpenRouter"
+          apiKey: "user_provided"
+          baseURL: "https://openrouter.ai/api/v1"
+          models:
+            default: ["openrouter/auto"]
+            fetch: true
+          titleConvo: true
+          titleModel: "openai/gpt-4o-mini"
+          modelDisplayLabel: "OpenRouter"
+        - name: "Fireworks"
+          apiKey: "user_provided"
+          baseURL: "https://api.fireworks.ai/inference/v1"
+          models:
+            default: ["accounts/fireworks/models/llama-v3p1-70b-instruct"]
+            fetch: true
+          titleConvo: true
+          titleModel: "accounts/fireworks/models/llama-v3p1-8b-instruct"
+          modelDisplayLabel: "Fireworks"
 
     fileConfig:
       endpoints:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -33,6 +33,31 @@ global:
   librechat:
     existingSecretName: "librechat-credentials-env"
     existingSecretApiKey: OPENAI_API_KEY
+    # Direct env entries on the LibreChat container. These render as
+    # `env:` (not `envFrom:`) so they OVERRIDE same-key entries from
+    # `librechat-credentials-env` — the Secret is shared with prod, so
+    # this is how we flip BYOK behavior on beta only without touching
+    # the Secret. K8s precedence: direct `env:` > later `envFrom:` >
+    # earlier `envFrom:`.
+    #
+    # `*_API_KEY=user_provided` is the signal that PR cbioportal/librechat#26
+    # (Add BYOK provider key settings) looks for to enable the per-provider
+    # BYOK input field under Settings → Data. Without the env override
+    # users on beta would still inherit prod's static keys (or Bedrock).
+    env:
+      - name: ANTHROPIC_API_KEY
+        value: "user_provided"
+      - name: OPENAI_API_KEY
+        value: "user_provided"
+      - name: GOOGLE_KEY
+        value: "user_provided"
+      - name: AZURE_API_KEY
+        value: "user_provided"
+      # Replace the Secret's ENDPOINTS list (defaults to `bedrock,agents`)
+      # so the four standard BYOK endpoints plus the custom block defined
+      # in librechat-config-beta show up in the endpoint selector.
+      - name: ENDPOINTS
+        value: "bedrock,agents,anthropic,openAI,google,azureOpenAI,custom"
 
 librechat:
   existingSecretName: "librechat-credentials-env"


### PR DESCRIPTION
Pairs with cbioportal/librechat#26 (already merged to the \`beta\` branch). That PR adds a Settings → Data UI for users to enter their own provider keys when the corresponding \`*_API_KEY\` env is set to \`user_provided\`, plus BYOK-aware balance behavior.

## Two files, beta-only

### \`apps/cbioagent-beta/values.yaml\`

- \`global.librechat.env\`: the chart renders this list as direct \`env:\` on the container. K8s precedence puts direct \`env:\` above \`envFrom:\`, so we override the shared \`librechat-credentials-env\` Secret on beta without touching it (the Secret is shared with prod).
- Set \`ANTHROPIC_API_KEY\` / \`OPENAI_API_KEY\` / \`GOOGLE_KEY\` / \`AZURE_API_KEY\` to \`\"user_provided\"\` so all four standard endpoints (PR #26's hardcoded map) surface BYOK fields.
- Set \`ENDPOINTS=bedrock,agents,anthropic,openAI,google,azureOpenAI,custom\` so the endpoints actually show up in chat, not just in settings.

### \`apps/cbioagent-beta/librechat-config.yaml\`

- New \`endpoints.custom:\` block with **OpenRouter** and **Fireworks**. Both use \`apiKey: \"user_provided\"\` (same BYOK signal for custom endpoints) and \`models.fetch: true\` so we don't have to pin specific models.

## Prod untouched

- \`apps/cbioagent/values.yaml\` and \`apps/cbioagent/librechat-config.yaml\` are not modified.
- The shared \`librechat-credentials-env\` Secret is not modified.
- Promotion of BYOK to prod stays a deliberate values bump later.

## Test plan

- [ ] After Argo sync + Reloader rollout: \`kubectl describe deploy cbioagent-librechat-beta\` shows direct env entries for the four \`*_API_KEY\` keys and \`ENDPOINTS\` with the new list.
- [ ] \`curl -s https://beta.chat.cbioportal.org/api/config | jq '.endpoints'\` lists \`anthropic\`, \`openAI\`, \`google\`, \`azureOpenAI\`, \`custom\` (with OpenRouter + Fireworks under custom).
- [ ] Settings → Data on beta shows BYOK fields for the four standard providers plus OpenRouter / Fireworks under custom.
- [ ] Entering a personal key for any provider lets that endpoint work without falling back to the shared key.
- [ ] Prod (\`chat.cbioportal.org\`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)