### PR TITLE
Add S3 mountpoint CSI resources for hackathon-databricks bucket

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pv.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pv.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: hackathon-databricks-s3-pv
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - allow-delete
+    - region us-east-1
+  claimRef:
+    namespace: airflow
+    name: hackathon-databricks-s3-pvc
+  csi:
+    driver: s3.csi.aws.com
+    volumeHandle: hackathon-databricks-s3-volume
+    volumeAttributes:
+      bucketName: 'hackathon-databricks'

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pv.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pv.yaml
@@ -15,6 +15,6 @@ spec:
     name: databricks-s3-pvc
   csi:
     driver: s3.csi.aws.com
-    volumeHandle: databricks-s3-volume
+    volumeHandle: databricks-s3-sc-203403084713-pp-4rxlzd426npxu-bucket-kswubqqre3jr
     volumeAttributes:
       bucketName: 'sc-203403084713-pp-4rxlzd426npxu-bucket-kswubqqre3jr'

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pv.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pv.yaml
@@ -1,20 +1,20 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: hackathon-databricks-s3-pv
+  name: databricks-s3-pv
 spec:
   capacity:
     storage: 500Gi
   accessModes:
-    - ReadWriteMany
+    - ReadOnlyMany
   mountOptions:
-    - allow-delete
+    - read-only
     - region us-east-1
   claimRef:
     namespace: airflow
-    name: hackathon-databricks-s3-pvc
+    name: databricks-s3-pvc
   csi:
     driver: s3.csi.aws.com
-    volumeHandle: hackathon-databricks-s3-volume
+    volumeHandle: databricks-s3-volume
     volumeAttributes:
-      bucketName: 'hackathon-databricks'
+      bucketName: 'sc-203403084713-pp-4rxlzd426npxu-bucket-kswubqqre3jr'

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pvc.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hackathon-databricks-s3-pvc
+  namespace: airflow
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 500Gi
+  volumeName: hackathon-databricks-s3-pv

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pvc.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/s3-pvc.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: hackathon-databricks-s3-pvc
+  name: databricks-s3-pvc
   namespace: airflow
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadOnlyMany
   storageClassName: ""
   resources:
     requests:
       storage: 500Gi
-  volumeName: hackathon-databricks-s3-pv
+  volumeName: databricks-s3-pv

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
@@ -13,6 +13,11 @@ postgresql:
 registry:
   secretName: "dockerhub-creds"
 
+# IAM role for S3 Mountpoint CSI driver — allows DAG pods to mount hackathon-databricks bucket
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::666628074417:role/userServiceRoleHackathonS3Mountpoint"
+
 config:
   api:
     access_control_allow_headers: origin, content-type, accept

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/airflow/values.yaml
@@ -13,10 +13,10 @@ postgresql:
 registry:
   secretName: "dockerhub-creds"
 
-# IAM role for S3 Mountpoint CSI driver — allows DAG pods to mount hackathon-databricks bucket
+# IAM role for S3 Mountpoint CSI driver — allows DAG pods to mount the cross-account Databricks S3 bucket
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::666628074417:role/userServiceRoleHackathonS3Mountpoint"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::666628074417:role/userServiceRoleDatabricksS3Mountpoint"
 
 config:
   api:

--- a/iac/aws/203403084713/shared/s3/main.tf
+++ b/iac/aws/203403084713/shared/s3/main.tf
@@ -7,6 +7,12 @@ data "aws_iam_role" "github-lfs-lambda-role" {
 locals {
   datahub_bucket_name = one([for o in aws_servicecatalog_provisioned_product.cbioportal-datahub.outputs : o.value if o.key == "ContentBucket"])
   datahub_cf_dist_id  = one([for o in aws_servicecatalog_provisioned_product.cbioportal-datahub.outputs : o.value if o.key == "CloudFrontDistribution"])
+
+  # Service Catalog provisioned bucket read by the MSK (666628074417) airflow
+  # importer via the S3 Mountpoint CSI driver. The MSK-side IAM role is defined
+  # in iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf.
+  databricks_target_bucket_name = "sc-203403084713-pp-4rxlzd426npxu-bucket-kswubqqre3jr"
+  databricks_msk_csi_role_arn   = "arn:aws:iam::666628074417:role/userServiceRoleDatabricksS3Mountpoint"
 }
 
 resource "aws_servicecatalog_provisioned_product" "cBioPortal_Public_DB_Dump" {
@@ -134,6 +140,49 @@ resource "aws_s3_bucket_policy" "cbioportal-datahub-policy" {
         Condition = {
           StringNotEquals = {
             "aws:PrincipalArn" = data.aws_iam_role.github-lfs-lambda-role.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+# WARNING: a bucket policy is a single document per bucket. If AWS Service
+# Catalog (or Databricks) already manages a policy on this bucket, applying
+# this REPLACES it — merge in any existing statements before applying.
+resource "aws_s3_bucket_policy" "databricks-target-msk-csi-policy" {
+  bucket = local.databricks_target_bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowMskAirflowCsiReadOnly"
+        Effect = "Allow"
+        Principal = {
+          AWS = local.databricks_msk_csi_role_arn
+        }
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject"
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.databricks_target_bucket_name}",
+          "arn:aws:s3:::${local.databricks_target_bucket_name}/*"
+        ]
+      },
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "arn:aws:s3:::${local.databricks_target_bucket_name}",
+          "arn:aws:s3:::${local.databricks_target_bucket_name}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
           }
         }
       }

--- a/iac/aws/203403084713/shared/s3/main.tf
+++ b/iac/aws/203403084713/shared/s3/main.tf
@@ -147,46 +147,56 @@ resource "aws_s3_bucket_policy" "cbioportal-datahub-policy" {
   })
 }
 
-# WARNING: a bucket policy is a single document per bucket. If AWS Service
-# Catalog (or Databricks) already manages a policy on this bucket, applying
-# this REPLACES it — merge in any existing statements before applying.
+
+# Read existing bucket policy so we can merge rather than replace
+data "aws_s3_bucket_policy" "databricks_target_existing" {
+  bucket = local.databricks_target_bucket_name
+}
+
+locals {
+  databricks_existing_policy_json = try(data.aws_s3_bucket_policy.databricks_target_existing.policy, "{}")
+  databricks_existing_policy      = try(jsondecode(local.databricks_existing_policy_json), { Version = "2012-10-17", Statement = [] })
+}
+
 resource "aws_s3_bucket_policy" "databricks-target-msk-csi-policy" {
   bucket = local.databricks_target_bucket_name
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowMskAirflowCsiReadOnly"
-        Effect = "Allow"
-        Principal = {
-          AWS = local.databricks_msk_csi_role_arn
-        }
-        Action = [
-          "s3:ListBucket",
-          "s3:GetObject"
-        ]
-        Resource = [
-          "arn:aws:s3:::${local.databricks_target_bucket_name}",
-          "arn:aws:s3:::${local.databricks_target_bucket_name}/*"
-        ]
-      },
-      {
-        Sid       = "DenyInsecureTransport"
-        Effect    = "Deny"
-        Principal = "*"
-        Action    = "s3:*"
-        Resource = [
-          "arn:aws:s3:::${local.databricks_target_bucket_name}",
-          "arn:aws:s3:::${local.databricks_target_bucket_name}/*"
-        ]
-        Condition = {
-          Bool = {
-            "aws:SecureTransport" = "false"
+    Statement = concat(
+      local.databricks_existing_policy.Statement,
+      [
+        {
+          Sid    = "AllowMskAirflowCsiReadOnly"
+          Effect = "Allow"
+          Principal = {
+            AWS = local.databricks_msk_csi_role_arn
+          }
+          Action = [
+            "s3:ListBucket",
+            "s3:GetObject"
+          ]
+          Resource = [
+            "arn:aws:s3:::${local.databricks_target_bucket_name}",
+            "arn:aws:s3:::${local.databricks_target_bucket_name}/*"
+          ]
+        },
+        {
+          Sid       = "DenyInsecureTransport"
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource = [
+            "arn:aws:s3:::${local.databricks_target_bucket_name}",
+            "arn:aws:s3:::${local.databricks_target_bucket_name}/*"
+          ]
+          Condition = {
+            Bool = {
+              "aws:SecureTransport" = "false"
+            }
           }
         }
-      }
-    ]
+      ]
+    )
   })
 }
-

--- a/iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf
@@ -4,6 +4,7 @@ locals {
   cluster_name = var.cluster_name
   permissions_boundary_policy    = "AutomationOrUserServiceRolePermissions"
   cellxgene_s3_mountpoint_bucket = "cellxgene-data-msk"
+  hackathon_s3_mountpoint_bucket = "hackathon-databricks"
 }
 
 data "aws_caller_identity" "current" {}
@@ -89,4 +90,82 @@ resource "aws_iam_role" "userServiceRoleCellxgeneS3Mountpoint" {
 resource "aws_iam_role_policy_attachment" "userServicePolicyAttachmentCellxgeneS3Mountpoint" {
   policy_arn = aws_iam_policy.userServicePolicyCellxgeneS3Mountpoint.arn
   role       = aws_iam_role.userServiceRoleCellxgeneS3Mountpoint.name
+}
+
+# ── Hackathon S3 mountpoint ──────────────────────────────────────────
+resource "aws_iam_policy" "userServicePolicyHackathonS3Mountpoint" {
+  name        = "userServicePolicyHackathonS3Mountpoint"
+  path        = "/"
+  description = "Policy to allow S3 Mountpoint CSI cluster add-on to access the hackathon-databricks S3 bucket"
+
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "MountpointFullBucketAccess",
+          "Effect" : "Allow",
+          "Action" : [
+            "s3:ListBucket"
+          ],
+          "Resource" : [
+            "arn:aws:s3:::${local.hackathon_s3_mountpoint_bucket}"
+          ]
+        },
+        {
+          "Sid" : "MountpointReadObjectAccess",
+          "Effect" : "Allow",
+          "Action" : [
+            "s3:GetObject"
+          ],
+          "Resource" : [
+            "arn:aws:s3:::${local.hackathon_s3_mountpoint_bucket}/*"
+          ]
+        }
+      ]
+    }
+  )
+
+  tags = {
+    cdsi-owner = "jamesko@mskcc.org"
+    cdsi-app   = "cmo-pipelines"
+    cdsi-team  = "data-visualization"
+  }
+}
+
+resource "aws_iam_role" "userServiceRoleHackathonS3Mountpoint" {
+  name = "userServiceRoleHackathonS3Mountpoint"
+
+  assume_role_policy = jsonencode(
+    {
+      Version = "2012-10-17",
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = "sts:AssumeRoleWithWebIdentity",
+          Principal = {
+            Federated = "arn:aws:iam::${local.account_id}:oidc-provider/${var.cluster_oidc_provider_arn}"
+          },
+          Condition = {
+            StringEquals = {
+              "${var.cluster_oidc_provider_arn}:aud" = "sts.amazonaws.com"
+            }
+          }
+        }
+      ]
+    }
+  )
+
+  permissions_boundary = "arn:aws:iam::${local.account_id}:policy/${local.permissions_boundary_policy}"
+
+  tags = {
+    cdsi-owner = "jamesko@mskcc.org"
+    cdsi-app   = "cmo-pipelines"
+    cdsi-team  = "data-visualization"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "userServicePolicyAttachmentHackathonS3Mountpoint" {
+  policy_arn = aws_iam_policy.userServicePolicyHackathonS3Mountpoint.arn
+  role       = aws_iam_role.userServiceRoleHackathonS3Mountpoint.name
 }

--- a/iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf
@@ -71,7 +71,7 @@ resource "aws_iam_role" "userServiceRoleCellxgeneS3Mountpoint" {
           },
           Condition = {
             StringEquals = {
-              "${var.cluster_oidc_provider_arn}:aud" = "sts.amazonaws.com"
+              "${var.cluster_oidc_provider_arn}:aud" = "sts.amazonaws.com",
             }
           }
         }
@@ -150,7 +150,8 @@ resource "aws_iam_role" "userServiceRoleDatabricksS3Mountpoint" {
           },
           Condition = {
             StringEquals = {
-              "${var.cluster_oidc_provider_arn}:aud" = "sts.amazonaws.com"
+              "${var.cluster_oidc_provider_arn}:aud" = "sts.amazonaws.com",
+              "${var.cluster_oidc_provider_arn}:sub" = "system:serviceaccount:airflow:airflow-worker"
             }
           }
         }

--- a/iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/iam/main.tf
@@ -4,7 +4,9 @@ locals {
   cluster_name = var.cluster_name
   permissions_boundary_policy    = "AutomationOrUserServiceRolePermissions"
   cellxgene_s3_mountpoint_bucket = "cellxgene-data-msk"
-  hackathon_s3_mountpoint_bucket = "hackathon-databricks"
+  # Cross-account (203403084713) Service Catalog bucket. Requires a matching
+  # bucket policy in 203403084713 naming this role as principal.
+  databricks_s3_mountpoint_bucket = "sc-203403084713-pp-4rxlzd426npxu-bucket-kswubqqre3jr"
 }
 
 data "aws_caller_identity" "current" {}
@@ -92,24 +94,24 @@ resource "aws_iam_role_policy_attachment" "userServicePolicyAttachmentCellxgeneS
   role       = aws_iam_role.userServiceRoleCellxgeneS3Mountpoint.name
 }
 
-# ── Hackathon S3 mountpoint ──────────────────────────────────────────
-resource "aws_iam_policy" "userServicePolicyHackathonS3Mountpoint" {
-  name        = "userServicePolicyHackathonS3Mountpoint"
+# ── Databricks S3 mountpoint ──────────────────────────────────────────
+resource "aws_iam_policy" "userServicePolicyDatabricksS3Mountpoint" {
+  name        = "userServicePolicyDatabricksS3Mountpoint"
   path        = "/"
-  description = "Policy to allow S3 Mountpoint CSI cluster add-on to access the hackathon-databricks S3 bucket"
+  description = "Policy to allow S3 Mountpoint CSI cluster add-on read-only access to the cross-account Databricks S3 bucket"
 
   policy = jsonencode(
     {
       "Version" : "2012-10-17",
       "Statement" : [
         {
-          "Sid" : "MountpointFullBucketAccess",
+          "Sid" : "MountpointBucketList",
           "Effect" : "Allow",
           "Action" : [
             "s3:ListBucket"
           ],
           "Resource" : [
-            "arn:aws:s3:::${local.hackathon_s3_mountpoint_bucket}"
+            "arn:aws:s3:::${local.databricks_s3_mountpoint_bucket}"
           ]
         },
         {
@@ -119,7 +121,7 @@ resource "aws_iam_policy" "userServicePolicyHackathonS3Mountpoint" {
             "s3:GetObject"
           ],
           "Resource" : [
-            "arn:aws:s3:::${local.hackathon_s3_mountpoint_bucket}/*"
+            "arn:aws:s3:::${local.databricks_s3_mountpoint_bucket}/*"
           ]
         }
       ]
@@ -133,8 +135,8 @@ resource "aws_iam_policy" "userServicePolicyHackathonS3Mountpoint" {
   }
 }
 
-resource "aws_iam_role" "userServiceRoleHackathonS3Mountpoint" {
-  name = "userServiceRoleHackathonS3Mountpoint"
+resource "aws_iam_role" "userServiceRoleDatabricksS3Mountpoint" {
+  name = "userServiceRoleDatabricksS3Mountpoint"
 
   assume_role_policy = jsonencode(
     {
@@ -165,7 +167,7 @@ resource "aws_iam_role" "userServiceRoleHackathonS3Mountpoint" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "userServicePolicyAttachmentHackathonS3Mountpoint" {
-  policy_arn = aws_iam_policy.userServicePolicyHackathonS3Mountpoint.arn
-  role       = aws_iam_role.userServiceRoleHackathonS3Mountpoint.name
+resource "aws_iam_role_policy_attachment" "userServicePolicyAttachmentDatabricksS3Mountpoint" {
+  policy_arn = aws_iam_policy.userServicePolicyDatabricksS3Mountpoint.arn
+  role       = aws_iam_role.userServiceRoleDatabricksS3Mountpoint.name
 }

--- a/iac/aws/666628074417/clusters/cbioportal-prod/iam/outputs.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/iam/outputs.tf
@@ -3,7 +3,7 @@ output "cellxgene_s3_mountpoint_role_arn" {
   description = "ARN of the IAM Role for the cellxgene s3 mountpoint"
 }
 
-output "hackathon_s3_mountpoint_role_arn" {
-  value       = aws_iam_role.userServiceRoleHackathonS3Mountpoint.arn
-  description = "ARN of the IAM Role for the hackathon s3 mountpoint"
+output "databricks_s3_mountpoint_role_arn" {
+  value       = aws_iam_role.userServiceRoleDatabricksS3Mountpoint.arn
+  description = "ARN of the IAM Role for the databricks s3 mountpoint"
 }

--- a/iac/aws/666628074417/clusters/cbioportal-prod/iam/outputs.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/iam/outputs.tf
@@ -2,3 +2,8 @@ output "cellxgene_s3_mountpoint_role_arn" {
   value       = aws_iam_role.userServiceRoleCellxgeneS3Mountpoint.arn
   description = "ARN of the IAM Role for the cellxgene s3 mountpoint"
 }
+
+output "hackathon_s3_mountpoint_role_arn" {
+  value       = aws_iam_role.userServiceRoleHackathonS3Mountpoint.arn
+  description = "ARN of the IAM Role for the hackathon s3 mountpoint"
+}


### PR DESCRIPTION
- IAM: new policy/role (userServiceRoleHackathonS3Mountpoint) for hackathon-databricks bucket read-only access via S3 Mountpoint CSI
- EKS: add airflow-importer-dag toleration to mountpoint addon so DaemonSet runs on importer nodes
- PV/PVC: static PersistentVolume + Claim for hackathon-databricks in the airflow namespace (s3.csi.aws.com driver)
- Helm: annotate airflow-airflow SA with IAM role ARN for IRSA