### PR TITLE
argocd (666): enable auto-sync + self-heal on portal-configuration

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/portal-configuration.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/portal-configuration.yaml
@@ -25,3 +25,7 @@ spec:
   destination:
     namespace: default
     server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
The `portal-configuration` app on 666 has been sync-only-on-button-press since day one. Every other app on the cluster (`cbioagent`, `cbioagent-beta`, `cbioagent-db`, `cbioagent-msk-configmaps`, `keel`, `reloader`, etc.) already runs with `automated.prune=true, selfHeal=true`, so `librechat-config` changes were the odd one out.

Now that Reloader is wired up (knowledgesystems-k8s-deployment#498), a merged PR to portal-configuration should flow through to a running pod without a human clicking the Sync button. Right now it doesn't — Reloader is watching a ConfigMap that only updates when someone remembers to click.

## Change

```yaml
syncPolicy:
  automated:
    prune: true
    selfHeal: true
```

Same shape as every other app on the cluster.

## Effect

- Merges to `portal-configuration:main` reach 666 within Argo's refresh interval (~3 min).
- Manual edits to `librechat-config` / `librechat-credentials-env` get reverted back to git (`selfHeal`).
- Orphaned resources removed by a PR are cleaned up (`prune`).

Nothing here changes what the app manages — just the sync policy.