### PR TITLE
Enable self-healing and auto-prune for cbioportal in eks cluster

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/cbioportal.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/cbioportal.yaml
@@ -14,4 +14,8 @@ spec:
   destination:
     namespace: default
     server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
   revisionHistoryLimit: 3


### PR DESCRIPTION
we need to merge & deploy changes to com-pipelines to disable self-healing during the blue-green switchover process first, which updates the deployment multiple times in succession before completing the switchover. enabling self-healing before it is dealt with properly will break the current import flow