### PR TITLE
feat: mirror aws creds secret into cell-explorer namespace

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/aws-creds-rbac.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/aws-creds-rbac.yaml
@@ -1,0 +1,26 @@
+# Lets the k8s-aws-creds-manager cronjob (its SA lives in the default namespace)
+# write the aws credentials Secret into this namespace, so cell-explorer pods can
+# mount it. Secret volumes only resolve within the pod's own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-aws-creds-manager-secret-writer
+  namespace: cell-explorer
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-aws-creds-manager-secret-writer
+  namespace: cell-explorer
+subjects:
+  - kind: ServiceAccount
+    name: k8s-aws-creds-manager-pod-restarter
+    namespace: default
+roleRef:
+  kind: Role
+  name: k8s-aws-creds-manager-secret-writer
+  apiGroup: rbac.authorization.k8s.io

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/k8s-aws-creds-manager/cronjob.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/k8s-aws-creds-manager/cronjob.yaml
@@ -83,6 +83,12 @@ spec:
                     --from-file=credentials=$HOME/.aws/credentials \
                     --dry-run=client -o yaml | kubectl apply -f -
 
+                  # Mirror into the cell-explorer namespace — its pods can only
+                  # mount secrets from their own namespace
+                  kubectl create secret generic k8s-aws-creds-manager \
+                    --from-file=credentials=$HOME/.aws/credentials \
+                    --dry-run=client -o yaml | kubectl apply -n cell-explorer -f -
+
                   echo "Done. Credentials secret updated."
           nodeSelector:
             workload: cbioportal


### PR DESCRIPTION
The `k8s-aws-creds-manager` cronjob writes the aws credentials Secret only into the `default` namespace, where all current consumers (cbioagent, assistant-api) run. cell-explorer runs in its own `cell-explorer` namespace, and a pod can only mount secrets from its own namespace — so it can't reach the creds it needs for Bedrock access.

## Changes
- **cronjob.yaml** — also `kubectl apply` the Secret into the `cell-explorer` namespace.
- **cell-explorer/aws-creds-rbac.yaml** — a Role + RoleBinding in `cell-explorer` granting the cronjob's service account (which lives in `default`) permission to write the Secret there. Without it the new apply fails `Forbidden` — the SA's existing grant is namespaced to `default`.

## Rollout
- The Secret appears in `cell-explorer` on the cronjob's next run (every 6h); the RBAC syncs via the manual-sync cell-explorer Argo app.
- No change to the `default`-namespace Secret or existing consumers.