### PR TITLE
feat(cell-explorer): mount aws creds for Bedrock chat

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: cell-explorer
   labels:
     app: cell-explorer
+  annotations:
+    # Restart when the aws creds (refreshed on a schedule) or app secrets change.
+    secret.reloader.stakater.com/reload: "k8s-aws-creds-manager,cell-explorer-secrets"
 spec:
   replicas: 1
   strategy:
@@ -38,6 +41,11 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+            # AWS credentials for Bedrock (account 490004633549); the container
+            # runs as root, so HOME=/root and the SDK reads /root/.aws/credentials.
+            - name: aws-creds
+              mountPath: /root/.aws
+              readOnly: true
           # Alembic migrations run before uvicorn serves /health; give a slow
           # first-boot migration up to 5min before liveness/readiness apply.
           startupProbe:
@@ -71,6 +79,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: cell-explorer-data
+        - name: aws-creds
+          secret:
+            secretName: k8s-aws-creds-manager
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Enables AWS Bedrock as the chat LLM backend for cell-explorer.

## Changes (deployment.yaml)
- Mount the `k8s-aws-creds-manager` secret at `/root/.aws` (readOnly). The container runs as root, so the AWS SDK reads `/root/.aws/credentials`; `AWS_PROFILE=490004633549` (set in the configmap) selects the Bedrock account.
- Add `secret.reloader.stakater.com/reload: "k8s-aws-creds-manager,cell-explorer-secrets"` so the pod restarts when the creds are refreshed (every 6h) or app secrets change.

## Depends on
- The creds secret now exists in the `cell-explorer` namespace (#518).
- Paired portal-configuration PR sets `CHAT_LLM_TRANSPORT=bedrock`, `CHAT_LLM_MODEL=us.anthropic.claude-sonnet-4-6`, `CHAT_BEDROCK_REGION=us-east-1`, `AWS_PROFILE=490004633549`.

## Rollout
Sync the configmap first, then this deployment — the volume/annotation change triggers one Recreate rollout that comes up with creds mounted and the Bedrock env. Revert = flip `CHAT_LLM_TRANSPORT` back to `anthropic`.