### PR TITLE
feat(cell-explorer): bump image to 0.3.0 for Bedrock support

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:0.2.0
+          image: ghcr.io/cbioportal/cell-explorer-py:0.3.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
`0.2.0` predates the `anthropic[bedrock]` (boto3/botocore) runtime dependency, so Bedrock chat fails at runtime with `No module named 'botocore'`. `0.3.0` (released today, `cell-explorer-api-v0.3.0`) is built from current main and includes it.

Completes the Bedrock enablement (configmap #42 + creds mount #519 already merged).