### PR TITLE
fix: add missing Datadog env vars to MSK cluster cbioportal-mcp deployment

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -17,8 +17,6 @@ spec:
     metadata:
       labels:
         run: cbioagent-clickhouse-mcp
-      annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-15"
     spec:
       containers:
         - name: cbioagent-clickhouse-mcp

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         run: cbioagent-clickhouse-mcp
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-07-15"
     spec:
       containers:
         - name: cbioagent-clickhouse-mcp

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         run: cbioagent-clickhouse-mcp
+      annotations:
+        kubectl.kubernetes.io/restartedAt: "2026-07-15"
     spec:
       containers:
         - name: cbioagent-clickhouse-mcp
@@ -26,6 +28,16 @@ spec:
           ports:
             - containerPort: 8000
           env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_SERVICE_NAME
+              value: "cbioportal-mcp"
+            - name: DD_LLMOBS_ML_APP
+              value: "cbioportal-mcp"
+            - name: DD_SITE
+              value: "datadoghq.com"
             # Mount FastMCP under the external sub-path so trailing-slash
             # redirects point to https://chat.cbioportal.aws.mskcc.org/db/mcp/
             # rather than /mcp/. Paired with the cbioagent-db-ingress

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -18,8 +18,6 @@ spec:
     metadata:
       labels:
         run: cbioagent-clickhouse-mcp
-      annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-15"
     spec:
       containers:
         - name: cbioagent-clickhouse-mcp


### PR DESCRIPTION
## Summary

The `203403084713` (public prod) cluster's `cbioportal-mcp` deployment already had the Datadog env vars needed for tracing and LLM Observability. The `666628074417` (MSK) cluster was missing them, so the MCP server there sends no telemetry to Datadog at all.

This PR adds the four missing vars to the MSK cluster:

| Var | Purpose |
|-----|---------|
| `DD_AGENT_HOST` | Points OTel span export at the node-local Datadog agent (IP injected via k8s Downward API) |
| `OTEL_SERVICE_NAME` | Names the service `cbioportal-mcp` in Datadog APM |
| `DD_LLMOBS_ML_APP` | Names the app `cbioportal-mcp` in Datadog LLM Observability — enables `@ml_app:cbioportal-mcp` filtering |
| `DD_SITE` | Routes ddtrace to `datadoghq.com` |

Follow-up to #517.

## Test plan

- [ ] After merging, manually redeploy the `cbioagent-clickhouse-mcp` pod in the MSK cluster
- [ ] Make a test tool call via the MSK cBioPortalChat instance and confirm `ml_app:cbioportal-mcp` spans appear in **Datadog LLM Observability → Traces**

🤖 Generated with [Claude Code](https://claude.com/claude-code)