### PR TITLE
fix: use correct LibreChat placeholder syntax for MCP user identity headers

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -104,22 +104,22 @@ data:
         type: streamable-http
         url: http://cbioagent-clickhouse-mcp:80/db/mcp
         headers:
-          x-user-id: "{{user.id}}"
-          x-user-email: "{{user.email}}"
+          x-user-id: "{{LIBRECHAT_USER_ID}}"
+          x-user-email: "{{LIBRECHAT_USER_EMAIL}}"
       cbioportal-navigator:
         type: streamable-http
         url: http://cbioportal-navigator:80/mcp
         chatMenu: false
         headers:
-          x-user-id: "{{user.id}}"
-          x-user-email: "{{user.email}}"
+          x-user-id: "{{LIBRECHAT_USER_ID}}"
+          x-user-email: "{{LIBRECHAT_USER_EMAIL}}"
       cbioportal-navigator-beta:
         type: streamable-http
         url: http://cbioportal-navigator-beta:80/mcp
         chatMenu: false
         headers:
-          x-user-id: "{{user.id}}"
-          x-user-email: "{{user.email}}"
+          x-user-id: "{{LIBRECHAT_USER_ID}}"
+          x-user-email: "{{LIBRECHAT_USER_EMAIL}}"
 
     endpoints:
       agents:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -112,15 +112,15 @@ data:
         type: streamable-http
         url: http://cbioagent-clickhouse-mcp:80/db/mcp
         headers:
-          x-user-id: "{{user.id}}"
-          x-user-email: "{{user.email}}"
+          x-user-id: "{{LIBRECHAT_USER_ID}}"
+          x-user-email: "{{LIBRECHAT_USER_EMAIL}}"
       cbioportal-navigator:
         type: streamable-http
         url: http://cbioportal-navigator:80/mcp
         chatMenu: false
         headers:
-          x-user-id: "{{user.id}}"
-          x-user-email: "{{user.email}}"
+          x-user-id: "{{LIBRECHAT_USER_ID}}"
+          x-user-email: "{{LIBRECHAT_USER_EMAIL}}"
 
     endpoints:
       agents:


### PR DESCRIPTION
## Summary

The previous header config used `{{user.id}}` and `{{user.email}}` which are not valid LibreChat placeholder syntax. LibreChat's `processMCPEnv()` → `processUserPlaceholders()` function resolves the pattern `{{LIBRECHAT_USER_<FIELD>}}` (source: `packages/api/src/utils/env.ts`). The wrong syntax was silently ignored, so `x-user-id` was never sent to the MCP server and `usr.id` never appeared on Datadog spans.

Fixes both prod and beta configs.

## Test plan

- [ ] After merging, hard refresh + sync `cbioagent` and `cbioagent-beta` in ArgoCD to reload the ConfigMap and restart LibreChat
- [ ] Make a tool call via cBioPortalChat and confirm `usr.id` now appears on `mcp.tool.*` spans in **Datadog AI Observability → Traces**

🤖 Generated with [Claude Code](https://claude.com/claude-code)