### PR TITLE
Auto-roll cbioportal-navigator and clickhouse-mcp Deployments on image push (Keel)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/cbioportal-navigator-beta.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/cbioportal-navigator-beta.yaml
@@ -11,6 +11,14 @@ metadata:
   name: cbioportal-navigator-beta
   labels:
     run: cbioportal-navigator-beta
+  annotations:
+    # Keel polls ghcr for `:beta` and rolls this Deployment when the
+    # digest changes. Without this, `imagePullPolicy: Always` only pulls
+    # a new image on pod restart — a beta-branch push doesn't roll the
+    # pod on its own.
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/match-tag: "true"
 spec:
   replicas: 1
   selector:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -8,6 +8,14 @@ metadata:
     # Reloader rolls this Deployment when the daily clone cron patches
     # clickhouse-mcp-active.CLICKHOUSE_DATABASE on a successful build.
     configmap.reloader.stakater.com/reload: "clickhouse-mcp-active"
+    # Keel polls Docker Hub for `cbioportal/mcp:latest` and rolls the
+    # Deployment when the digest changes. Without this, `:latest` only
+    # gets re-pulled when the pod restarts for other reasons (daily clone
+    # via Reloader, evictions), so MCP-server fixes can lag by up to a
+    # day even though `imagePullPolicy: Always` is set.
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/match-tag: "true"
 spec:
   replicas: 1
   selector:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioportal-navigator.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioportal-navigator.yaml
@@ -4,6 +4,14 @@ metadata:
   name: cbioportal-navigator
   labels:
     run: cbioportal-navigator
+  annotations:
+    # Keel polls ghcr for `:latest` and rolls this Deployment when the
+    # digest changes. Without this, `imagePullPolicy: Always` only pulls
+    # a new image on pod restart — a master push doesn't roll the pod on
+    # its own, so fixes can sit unshipped until something else evicts it.
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/match-tag: "true"
 spec:
   replicas: 1
   selector:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp.yaml
@@ -9,6 +9,14 @@ metadata:
     # changes — the daily clone cron flips that ConfigMap's
     # CLICKHOUSE_DATABASE on each successful build.
     configmap.reloader.stakater.com/reload: "clickhouse-mcp-active"
+    # Keel polls Docker Hub for `cbioportal/mcp:latest` and rolls the
+    # Deployment when the digest changes. Without this, `:latest` only
+    # gets re-pulled when the pod restarts for other reasons (daily clone
+    # via Reloader, evictions), so MCP-server fixes can lag by up to a
+    # day even though `imagePullPolicy: Always` is set.
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/match-tag: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary

Add `keel.sh/policy: force` + `keel.sh/trigger: poll` + `keel.sh/match-tag: \"true\"` annotations to four Deployments so a fresh mutable-tag digest rolls the pod without needing a manual restart:

- `cbioportal-navigator` (203, `:latest` on ghcr)
- `cbioportal-navigator-beta` (203, `:beta` on ghcr)
- `cbioagent-clickhouse-mcp` (203, `cbioportal/mcp:latest` on Docker Hub)
- `cbioagent-clickhouse-mcp` (666, `cbioportal/mcp:latest` on Docker Hub)

## Why

All four Deployments use mutable tags with `imagePullPolicy: Always`. Argo sees no diff when the image string is unchanged, so nothing rolls the pod on a new build — the tag only gets re-pulled on unrelated pod restart.

- **Navigator:** PR #50 on cbioportal/cbioportal-navigator (405-on-GET/DELETE reconnect-storm fix) landed on master 2026-07-01 but only reached the prod pod ~today when something else evicted it, and beta was 5 commits behind so beta didn't have it at all.
- **clickhouse-mcp:** the daily clone cron patches `clickhouse-mcp-active`, which Reloader-bounces the pod as a side effect — bounding staleness to ~24h — but that's incidental, not by design.

Matches the existing Keel pattern on `cbioagent-beta` (LibreChat) — see values.yaml deploymentAnnotations at HEAD.

## Test plan

- [ ] Argo syncs each Deployment cleanly (annotation-only diff)
- [ ] `kubectl describe deploy/cbioportal-navigator -n default` shows the three keel annotations
- [ ] Next master push on cbioportal-navigator produces a new `:latest` and the prod pod rolls within ~5 min without manual action
- [ ] Next push of `cbioportal/mcp:latest` rolls both clickhouse-mcp Deployments within ~5 min