### PR TITLE
feat(cell-explorer): bump image to 0.4.0

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:0.3.0
+          image: ghcr.io/cbioportal/cell-explorer-py:0.4.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Bumps cell-explorer to `0.4.0` (`cell-explorer-api-v0.4.0`, released today).

Ships the per-dataset default-view backend (cell-explorer-py #170).