### PR TITLE
Update msk staging deployment to match blue conventions

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-staging-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-staging-deployment-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: cbioportal:apps/Deployment:default/eks-msk-staging
   labels:
     run: eks-msk-staging
     tags.datadoghq.com/env: eks-msk-staging
@@ -22,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        admission.datadoghq.com/java-lib.version: v1.24.2
+        admission.datadoghq.com/java-lib.version: v1.59.0
       labels:
         admission.datadoghq.com/enabled: "true"
         run: eks-msk-staging
@@ -268,6 +270,18 @@ spec:
           value: "true"
         - name: DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION
           value: "true"
+        - name: DD_PROFILING_ENDPOINT_COLLECTION_ENABLED
+          value: "true"
+        - name: DD_PROFILING_ALLOCATION_ENABLED
+          value: "true"
+        - name: DD_PROFILING_HEAP_ENABLED
+          value: "true"
+        - name: DD_TRACE_ENABLED
+          value: "true"
+        - name: DD_APM_ENABLED
+          value: "true"
+        - name: DD_TRACE_ANALYTICS_ENABLED
+          value: "true"
         envFrom:
         - secretRef:
             name: cbioportal-msk-staging
@@ -360,6 +374,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    argocd.argoproj.io/tracking-id: cbioportal:/Service:default/eks-msk-staging
   labels:
     run: eks-msk-staging
   name: eks-msk-staging


### PR DESCRIPTION
Adds argocd tracking-id annotations, bumps Datadog java-lib version, and adds newer Datadog profiling/APM env vars