### PR TITLE
Block Huawei-Cloud-SG (PetalBot) range on oncokb-research Traefik

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/ingress/oncokb_beta_ingress.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/ingress/oncokb_beta_ingress.yaml
@@ -9,6 +9,7 @@ spec:
     - kind: Rule
       match: Host(`beta.oncokb.org`)
       middlewares:
+        - name: ipblock
         - name: uablock-agentic-crawlers
       services:
         - name: oncokb-public-beta

--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/ingress/oncokb_ingress.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/ingress/oncokb_ingress.yaml
@@ -14,6 +14,7 @@ spec:
     - kind: Rule
       match: Host(`public.api.oncokb.org`)
       middlewares:
+        - name: ipblock
         - name: uablock-agentic-crawlers
       services:
         - name: oncokb-core-public
@@ -46,6 +47,7 @@ spec:
     - kind: Rule
       match: Host(`staging.oncokb.org`)
       middlewares:
+        - name: ipblock
         - name: uablock-agentic-crawlers
       services:
         - name: oncokb-public-staging
@@ -53,6 +55,7 @@ spec:
     - kind: Rule
       match: Host(`preview.oncokb.org`)
       middlewares:
+        - name: ipblock
         - name: uablock-agentic-crawlers
       services:
         - name: oncokb-public-preview
@@ -60,6 +63,7 @@ spec:
     - kind: Rule
       match: Host(`www.oncokb.org`)
       middlewares:
+        - name: ipblock
         - name: uablock-agentic-crawlers
       services:
         - name: oncokb-public

--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/traefik/ipblock-middleware.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/traefik/ipblock-middleware.yaml
@@ -1,0 +1,12 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ipblock
+  namespace: default
+spec:
+  plugin:
+    ipblock:
+      ipDenyList:
+        # Huawei-Cloud-SG (PetalBot). Fetches robots.txt but ignores it; crawls
+        # www.oncokb.org unthrottled. Datacenter range, no real users.
+        - 114.119.128.0/19

--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/traefik/values.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/traefik/values.yaml
@@ -87,6 +87,10 @@ gateway:
       namespacePolicy:
         from: All
 experimental:
+  plugins:
+    ipblock:
+      moduleName: "github.com/kvncrw/denyip"
+      version: "v1.1.0"
   localPlugins:
     uablock:
       type: localPath


### PR DESCRIPTION
## What

Blocks the Huawei-Cloud-SG (PetalBot) range `114.119.128.0/19` on the **oncokb-research** cluster's Traefik, matching the block already live for **cbioportal-prod**.

## Why

PetalBot (Huawei's search crawler) fetches `robots.txt` but ignores it, and crawls `www.oncokb.org` (and `public.api.oncokb.org`) unthrottled — it renders pages and fires the full backend fan-out. It's the **same crawler and IP range we already blocked for `www.cbioportal.org`**, where the block is confirmed 100% effective. This cluster had no IP-block mechanism, so OncoKB was still being hit unrestricted.

A user-agent block won't work here: PetalBot uses a disguised `Mozilla/5.0 (Linux; Android 7.0)` UA for ~99% of its requests (only ~1% send the explicit `PetalBot` token), so only an IP block reliably stops it — the same reason `robots.txt` failed.

## Changes

- **`apps/traefik/values.yaml`** — installs the `denyip` Traefik plugin (`github.com/kvncrw/denyip` v1.1.0), the same plugin cbioportal-prod uses. oncokb-research previously installed only the local `uablock` plugin.
- **`apps/traefik/ipblock-middleware.yaml`** (new) — an `ipblock` Middleware denying `114.119.128.0/19`.
- **`apps/ingress/oncokb_ingress.yaml`** — attaches `ipblock` ahead of the existing `uablock-agentic-crawlers` on the public routes: `www.oncokb.org`, `public.api.oncokb.org`, `staging.oncokb.org`, `preview.oncokb.org`.

## Deploy notes

- **Safe:** `114.119.128.0/19` is a Huawei datacenter range — no real users originate from it (distinct from residential Singapore visitors).
- **Manual sync required:** the oncokb-research `traefik` ArgoCD app has no automated sync policy. After merge, **manually Sync the `traefik` app**. Because this changes Helm values (plugin install), the sync will roll the Traefik pods (brief edge blip).
- **How to verify:** the `denyip` plugin logs denials as access-log status `0` (not `403`) in this setup — confirm by "PetalBot `200`s to www.oncokb.org → 0", same signal used on cbioportal-prod.
- The cluster's `forwardedHeaders`/`proxyProtocol` `trustedIPs` already matches its VPC (`10.0.16.0/20`), so Traefik sees real client IPs and the block will be airtight (as verified on cbioportal-prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
