### PR TITLE
cell-explorer: bump prod image 0.4.0 -> sha-ea709af

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:0.4.0
+          image: ghcr.io/cbioportal/cell-explorer-py:sha-ea709af
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Bumps the prod `cell-explorer` image from `0.4.0` to `sha-ea709af` to deploy the current frontend `main`.

**Why a SHA tag (not a new version):** these are frontend-only changes (colorby: expanded palette, Uint16 category codes, tiered high-cardinality coloring, continuous obs coloring). The backend code is unchanged, so bumping `cell-explorer-api` would be misleading. The frontend is baked into the backend image at build time, so a fresh image is still required — pinned here by backend commit SHA.

The image `ghcr.io/cbioportal/cell-explorer-py:sha-ea709af` was built by cell-explorer-py CI on main after cBioPortal/cell-explorer-py#172 (which fixed the Dockerfile so the frontend clone actually busts cache — previously frontend changes could be silently cached/stale). Digest `sha256:85d2cc265aa72352f184c76de7648cdfe1ec74d277f8b5ed43a608e0ebc415ab`.

No backend schema changes; migrations run on boot as usual. Manual ArgoCD sync after merge.