### PR TITLE
Canary Sonnet 5 on beta LibreChat

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -58,6 +58,12 @@ global:
       # in librechat-config-beta show up in the endpoint selector.
       - name: ENDPOINTS
         value: "bedrock,agents,anthropic,openAI,google,azureOpenAI,custom"
+      # Beta canaries Claude Sonnet 5 while prod stays on Sonnet 4.5.
+      # `global.` prefix picks the global inference profile (routes across
+      # commercial regions with no residency guarantee) — 10% cheaper than
+      # `us.` regional/multi-region endpoints on Sonnet 4.5+.
+      - name: BEDROCK_AWS_MODELS
+        value: "global.anthropic.claude-sonnet-5"
 
 librechat:
   existingSecretName: "librechat-credentials-env"


### PR DESCRIPTION
## Summary

Add `BEDROCK_AWS_MODELS: \"global.anthropic.claude-sonnet-5\"` to `cbioagent-beta/values.yaml` `global.librechat.env` so **only** the beta LibreChat pod runs Sonnet 5. Prod stays on Sonnet 4.5 via the shared `librechat-credentials-env` Secret; K8s direct \`env:\` beats \`envFrom:\` on collision, so beta overrides just for itself.

## Why now

Sonnet 5 introductory pricing (\$2/\$10 per MTok in/out) is in effect through **2026-08-31**, then reverts to \$3/\$15 (same as Sonnet 4.5). Sonnet 5 uses a newer tokenizer that produces ~30% more tokens per unit of English text, so during the promo it's ~13% cheaper in real-world text terms, and after 2026-09-01 it's ~30% *more* expensive. A beta canary now gives us Langfuse latency + cost telemetry to make the keep-or-revert call before Sep 1.

## Profile choice: global vs. us

Bedrock exposes both `us.anthropic.claude-sonnet-5` (US-only, +10% regional premium) and `global.anthropic.claude-sonnet-5` (global routing, no premium) in account 490004633549 — both ACTIVE. Beta is a public canary, so `global.` is safe and picks up the extra 10% savings. When prod flips later, MSK (666) will likely want `us.` for data residency; that's a separate PR.

## Follow-ups (out of scope)

- Update the cbioNavigatorBeta/cBioPortalChat *beta* MongoDB agent record so its \`model\` field also points at \`global.anthropic.claude-sonnet-5\` (agent-endpoint binding).
- Watch Langfuse for ~1 week: p50/p90 total latency, TTFT, tokens/sec, cost per AgentRun.
- Prod cutover PR against \`portal-configuration\` (both accounts) once telemetry is happy.

## Test plan

- [ ] Argo syncs the beta app cleanly
- [ ] \`kubectl exec deploy/cbioagent-librechat-beta -n default -- printenv BEDROCK_AWS_MODELS\` returns \`global.anthropic.claude-sonnet-5\`
- [ ] \`curl -s https://beta.chat.cbioportal.org/api/config | jq '.endpoints.bedrock'\` lists Sonnet 5
- [ ] Live smoke chat on beta produces a Langfuse trace whose model field is \`global.anthropic.claude-sonnet-5\`