### PR TITLE
Canary Sonnet 4.6 on beta LibreChat (pivot from #535)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -58,17 +58,6 @@ global:
       # in librechat-config-beta show up in the endpoint selector.
       - name: ENDPOINTS
         value: "bedrock,agents,anthropic,openAI,google,azureOpenAI,custom"
-      # Beta lists BOTH Sonnet 4.5 and Sonnet 5 so users (and the
-      # cBioChatAgentBeta agent) can pick either. Sonnet 5 currently
-      # errors at invoke time — MSK org SCP `p-5neom9u0` blocks
-      # `anthropic.claude-sonnet-5` on 490004633549 and needs to be
-      # updated by MSK IT before Sonnet 5 is actually usable. Kept in the
-      # list so the switch is one agent-record update once the SCP lands.
-      # `global.` prefix picks the global inference profile (10% cheaper
-      # than `us.` regional/multi-region on Sonnet 4.5+, no residency
-      # guarantee).
-      - name: BEDROCK_AWS_MODELS
-        value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0,global.anthropic.claude-sonnet-5"
 
 librechat:
   existingSecretName: "librechat-credentials-env"

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -58,12 +58,17 @@ global:
       # in librechat-config-beta show up in the endpoint selector.
       - name: ENDPOINTS
         value: "bedrock,agents,anthropic,openAI,google,azureOpenAI,custom"
-      # Beta canaries Claude Sonnet 5 while prod stays on Sonnet 4.5.
-      # `global.` prefix picks the global inference profile (routes across
-      # commercial regions with no residency guarantee) — 10% cheaper than
-      # `us.` regional/multi-region endpoints on Sonnet 4.5+.
+      # Beta lists BOTH Sonnet 4.5 and Sonnet 5 so users (and the
+      # cBioChatAgentBeta agent) can pick either. Sonnet 5 currently
+      # errors at invoke time — MSK org SCP `p-5neom9u0` blocks
+      # `anthropic.claude-sonnet-5` on 490004633549 and needs to be
+      # updated by MSK IT before Sonnet 5 is actually usable. Kept in the
+      # list so the switch is one agent-record update once the SCP lands.
+      # `global.` prefix picks the global inference profile (10% cheaper
+      # than `us.` regional/multi-region on Sonnet 4.5+, no residency
+      # guarantee).
       - name: BEDROCK_AWS_MODELS
-        value: "global.anthropic.claude-sonnet-5"
+        value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0,global.anthropic.claude-sonnet-5"
 
 librechat:
   existingSecretName: "librechat-credentials-env"

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -58,6 +58,15 @@ global:
       # in librechat-config-beta show up in the endpoint selector.
       - name: ENDPOINTS
         value: "bedrock,agents,anthropic,openAI,google,azureOpenAI,custom"
+      # Beta canaries Sonnet 4.6 while prod stays on 4.5. Both listed so
+      # LibreChat's client-side allowlist doesn't reject the Sonnet 4.5
+      # fallback if we need to swap the agent record back. The `us.`
+      # prefix is required — MSK org SCP `p-5neom9u0` denies every
+      # `global.anthropic.claude-*` profile on this account for data
+      # residency. Sonnet 5 is invoke-blocked (Marketplace subscription
+      # not yet granted on 490004633549) so it's not in the list.
+      - name: BEDROCK_AWS_MODELS
+        value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0,us.anthropic.claude-sonnet-4-6"
 
 librechat:
   existingSecretName: "librechat-credentials-env"

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -60,11 +60,11 @@ global:
         value: "bedrock,agents,anthropic,openAI,google,azureOpenAI,custom"
       # Beta canaries Sonnet 4.6 while prod stays on 4.5. Both listed so
       # LibreChat's client-side allowlist doesn't reject the Sonnet 4.5
-      # fallback if we need to swap the agent record back. The `us.`
-      # prefix is required — MSK org SCP `p-5neom9u0` denies every
-      # `global.anthropic.claude-*` profile on this account for data
-      # residency. Sonnet 5 is invoke-blocked (Marketplace subscription
-      # not yet granted on 490004633549) so it's not in the list.
+      # fallback if we need to swap the agent record back. Only `us.`
+      # inference profiles are usable on this account — data-residency
+      # policy blocks `global.` Anthropic profiles. Sonnet 5 is not in
+      # the list because it's not yet subscribed via AWS Marketplace on
+      # the Bedrock account.
       - name: BEDROCK_AWS_MODELS
         value: "us.anthropic.claude-sonnet-4-5-20250929-v1:0,us.anthropic.claude-sonnet-4-6"
 


### PR DESCRIPTION
## Summary

Swap the beta LibreChat canary from Sonnet 5 (blocked) to **Sonnet 4.6** (working). Sets \`BEDROCK_AWS_MODELS\` on beta's \`global.librechat.env\` to \`us.anthropic.claude-sonnet-4-5-20250929-v1:0,us.anthropic.claude-sonnet-4-6\` — both listed so the beta agent can be swapped to 4.6 while keeping 4.5 available as a fallback.

## Why the pivot

Sonnet 5 (originally targeted by #535) hits two independent gates on the Bedrock account that are neither fast nor self-serviceable from available roles:

1. **AWS Marketplace subscription** for Sonnet 5 not yet granted; requires \`aws-marketplace:Subscribe\` — no available role holds it. Console and CLI both hit the same denial.
2. **Data-residency policy** blocks every \`global.\` Anthropic inference profile. So even once Marketplace is done, we'd have to use the \`us.\` prefix (10% regional premium).

Sonnet 4.6 avoids both: already subscribed, invokable via \`us.anthropic.claude-sonnet-4-6\` today, and priced identically to Sonnet 4.5 (\$3 input / \$15 output per MTok). Low-risk canary while the Sonnet 5 marketplace ask is handled separately.

## Companion work

- Beta MongoDB agent will be repointed to \`us.anthropic.claude-sonnet-4-6\` post-merge.
- Bedrock account details (SCP identifiers, exact denial text) tracked in \`portal-configuration\` per the msk-private-vs-public-repo convention.
- No change needed in \`cbioportal-mcp-qa\` for this step.

## Test plan

- [ ] Argo syncs cbioagent-beta cleanly (values-only diff)
- [ ] \`kubectl get deploy cbioagent-librechat-beta -n default -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="BEDROCK_AWS_MODELS")].value}'\` shows both models
- [ ] After the mongo flip, live chat on beta with cBioChatAgentBeta produces a Langfuse trace whose model is \`us.anthropic.claude-sonnet-4-6\`
- [ ] Selecting the Sonnet 4.5 model from the Bedrock endpoint dropdown still works