### PR TITLE
Enable Bedrock prompt caching on beta modelSpec

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -216,6 +216,13 @@ data:
             endpoint: "agents"
             agent_id: "agent_OHVSJI9Gd6gwsDnFSL-Xl"
             temperature: 0
+            # Bedrock prompt caching. On the Agents endpoint the request
+            # body's model_parameters win; without this flag the ~40k-token
+            # system+tools context is re-billed as fresh input every turn.
+            # With it, subsequent turns within cache TTL cost 0.1× input
+            # rate. Beta canary before flipping the prod modelSpec on 203
+            # and the four MSK modelSpecs on 666.
+            promptCache: true
             modelLabel: "cBioPortalChat"
             greeting: |
               Ask cBioPortalChat to explore cBioPortal data, build direct cBioPortal links, and answer questions about studies, genes, mutations, clinical attributes, and patient-level results. <a href="https://docs.cbioportal.org/ai-integrations/chat-interface/" target="_blank">Learn more</a>


### PR DESCRIPTION
## Summary

Add \`promptCache: true\` to the \`cBioChatAgentBeta\` modelSpec preset in \`cbioagent-beta/librechat-config.yaml\`. One-line effective change (plus comment). Beta canary before rolling to the prod modelSpec on 203 and the four MSK modelSpecs on 666.

## Why

Bedrock prompt caching is available in our \`v0.8.3-rc1-custom-v9\` build (feature landed in upstream via #8271). The Bedrock endpoint's provider code auto-enables \`promptCache=true\` for any \`claude\`/\`nova\` model — but the **Agents endpoint** doesn't inherit that default. It reads \`model_parameters\` from the request body (the modelSpec preset) or the agent's MongoDB \`model_parameters\` (empty on all our agents). Without an explicit \`promptCache: true\`, every turn re-bills the ~40k-token system+tools context at full input rate.

Recent Langfuse observations confirm the current state:

- \`us.anthropic.claude-sonnet-4-6\` traces from today all show \`cache_creation_input_tokens=0\` and \`cache_read_input_tokens=0\`
- Multiple calls with the identical 38,489-token input context re-billed at full rate every time

For a heavy-repeat-user pattern (currently ~\$85 total for one external data-curator user with 436 short prompts across 40 conversations, each convo paying the 40k bootstrap cost fresh), enabling caching should drop input cost on the hot path by ~10× (cache-read at 0.1× input rate).

## Test plan

- [ ] Argo syncs \`cbioagent-beta\` cleanly (ConfigMap-only diff, Reloader rolls the pod)
- [ ] Live chat on beta produces a Langfuse trace where at least one \`GENERATION\` has \`cache_creation_input_tokens > 0\`
- [ ] A follow-up turn in the same conversation shows \`cache_read_input_tokens > 0\` (within the 5-min cache TTL)
- [ ] Diff Langfuse tokens/AgentRun on \`cbioagent-librechat-beta\` vs \`cbioagent-librechat\` prod pod over 24-48 hours to confirm net input-cost reduction

## Prod rollout (separate PRs, once beta validates)

- \`knowledgesystems-k8s-deployment\` — 203 prod modelSpec in \`apps/cbioagent/librechat-config.yaml\` (agent \`agent_9ZXhcwLIsROBQX0u4JS5F\`)
- \`portal-configuration\` — 666 modelSpecs in \`.../666.../librechat-config.yaml\` (4 modelSpecs: cBioDBAgent, Databricks, Biomni, GN Fusion Annotation)