### PR TITLE
Add msktarget to 666 daily clone (alongside mskimpact)

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-clone-daily.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-clone-daily.yaml
@@ -1,6 +1,7 @@
-# Daily mskimpact-only clone of the active MSK cBioPortal production
+# Daily study-filtered clone of the active MSK cBioPortal production
 # color into a ping-pong librechat buffer in ClickHouse, with LLM-prep
-# SQL applied. Pod runs fetch-sql → load-msk-sql → clone → patch-pointer;
+# SQL applied. STUDY_FILTER accepts a comma-separated list of study
+# identifiers (currently mskimpact and msktarget). Pod runs fetch-sql → load-msk-sql → clone → patch-pointer;
 # Reloader watches clickhouse-mcp-active and rolls the MCP when the
 # patch container flips the buffer pointer.
 #
@@ -143,7 +144,7 @@ spec:
                 - name: DST_PREFIX
                   value: "cbioportal_msk_librechat_"
                 - name: STUDY_FILTER
-                  value: "mskimpact"
+                  value: "mskimpact,msktarget"
               volumeMounts:
                 - mountPath: /workdir
                   name: workdir


### PR DESCRIPTION
## Summary

Flip 666's daily ClickHouse-clone \`STUDY_FILTER\` env from \`mskimpact\` → \`mskimpact,msktarget\`. Pairs with knowledgesystems/portal-configuration#45 which updates the actual \`clone.sh\` (private repo — MSK-specific script) to parse the comma-separated list.

## Why

The MSK cbioAgent should have both MSK-IMPACT and MSK-TARGET data available for querying. Currently the daily clone only pulls MSK-IMPACT.

## Ordering

**Portal-configuration #45 must merge first** (or at least at the same time). Without the script update, this env change breaks the cron on the next run (line 106 of the current script does \`WHERE cancer_study_identifier='mskimpact,msktarget'\`, gets 0 rows, exits 1). Once the paired PR is in, the script parses the comma-separated list correctly and clones both studies in one run.

## Blast radius

- 666 only — 203 is a full-portal clone (\`STUDY_FILTER\` unset), completely unaffected.
- Clone target DB (blue/green) will start containing \`msktarget\` rows after the next successful run.
- Storage: adds MSK-TARGET's rows (relatively small — MSK-TARGET is much smaller than MSK-IMPACT). No storage concerns.

## Test plan

- [ ] knowledgesystems/portal-configuration#45 is merged first
- [ ] Argo syncs cbioagent on 666 (env-only diff on the CronJob spec)
- [ ] Manually trigger the CronJob after merge: \`kubectl create job --from=cronjob/cbioagent-clickhouse-clone-daily mskimpact-msktarget-seed-1 -n default\`
- [ ] Clone log shows validation \`2 studies validated: mskimpact, msktarget\`
- [ ] \`SELECT cancer_study_identifier, count(*) FROM <clone-target>.cancer_study GROUP BY 1\` shows both studies
- [ ] Sample counts on the clone match the source per-study counts
- [ ] MCP pod rolls (via Reloader) and answers questions about MSK-TARGET data