### PR TITLE
Pin beta LibreChat to v0.8.7-custom-v1 image

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -100,12 +100,14 @@ image:
   repository: cbioportal/librechat
   registry: docker.io
   pullPolicy: Always
-  # Beta follows the `beta` branch on cbioportal/librechat. The build
-  # workflow on that repo rebuilds and overwrites this mutable tag on
-  # every push, and Keel (see deploymentAnnotations above) rolls this
-  # pod when the digest behind the tag changes. Prod stays pinned to
-  # immutable v0.8.3-rc1-custom-vN tags so beta drift can't reach it.
-  tag: "beta"
+  # Beta pinned to the v0.8.7 rebase for validation. Built from the
+  # v0.8.7-custom-v1 branch on cbioportal/librechat (rebase of our
+  # v0.8.3-rc1-custom-v9 customizations on top of upstream v0.8.7 —
+  # brings agents-lib 3.2.46 with Bedrock cachePoint wiring, ~860
+  # upstream commits worth of fixes). Once soaked on beta we roll to
+  # prod under the same tag scheme. Keel still watches the tag digest;
+  # a re-push to v0.8.7-custom-v1 would still roll this pod.
+  tag: "v0.8.7-custom-v1"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:


### PR DESCRIPTION
## Summary

Flip beta LibreChat's image tag from \`beta\` (currently the stale, v0.8.3-based auto-build) to **\`v0.8.7-custom-v1\`**. That image is built from cbioportal/librechat's newly-created \`v0.8.7-custom-v1\` branch — a rebase of our v0.8.3-rc1-custom-v9 customizations onto upstream v0.8.7.

## Why

The Bedrock caching investigation earlier this week found the immediate ~\$85/user cost sink for workload traces to a missing agents-lib upgrade: 3.1.68 (our current v9 pin) only fires cache_control when \`provider === ANTHROPIC\` — Bedrock is dead code. 3.2.0+ adds \`hasBedrockPromptCache()\` that consumes \`clientOptions.promptCache === true\` for the Bedrock provider. Upstream v0.8.7 ships with 3.2.46. Rebasing our fork onto v0.8.7 was the cheapest path to bring that wiring in (plus ~860 upstream commits of other fixes).

## Rebase details

Local rebase completed at \`v0.8.7-cbioportal-rebase\` (pushed as \`v0.8.7-custom-v1\` on the fork):

- **52 of 60 custom commits applied** (22 clean + 28 with conflict resolution) + 2 post-rebase build fixups
- **8 skipped** with rationale — 3 lockfile-only bumps, 1 superseded agents-version bump, 1 superseded HTML sanitizer, 3 reasoning-toggle commits blocked by upstream client refactor, 2 context-summary commits non-viable because upstream removed \`handleContextStrategy\` from BaseClient
- **Build passes:** \`npm install\`, \`build:data-provider\`, \`build:data-schemas\`, \`build:api\`, \`build:client-package\`, frontend Vite build all OK. Tests not run.
- **Full report** at \`scratchpad/librechat-rebase-report.md\`

Two commits worth eyeballing before prod: \`c6eba964c\` (unified cBioAgent UI config, 7-file merge) and \`6557c9ff9\` (Switch Agent button, kept HEAD's HTML/non-HTML branching).

## Post-merge next steps

1. Argo syncs beta → new pod pulls \`v0.8.7-custom-v1\`
2. I flip beta agent's MongoDB \`model_parameters.promptCache: true\` (previously reverted; now it will actually do something)
3. Live 2-turn smoke chat on https://beta.chat.cbioportal.org/
4. Verify Langfuse shows \`cache_creation_input_tokens > 0\` on turn 1 and \`cache_read_input_tokens > 0\` on turn 2 within cache TTL
5. **After ~1 day of beta soak:** open a follow-up PR pinning **prod** on 203 + 666 to the same tag

## Known post-rebase gaps (out of scope for this PR)

- **Reasoning-actions toggle** (Foris's PR #28) needs re-implementation on top of upstream's rewritten Part/Reasoning/Thinking/ToolCall components. Beta users won't see the lightbulb icon until then.
- **Context summarization for agents** needs re-implementation against upstream's new context flow.

## Test plan

- [ ] Argo syncs cbioagent-beta cleanly (values.yaml only)
- [ ] Beta pod starts on the new image without crash loops
- [ ] Live chat produces a normal response
- [ ] Post-mongo-flip: Langfuse shows non-zero cache tokens on beta traces
- [ ] No 5xx spike in the beta pod logs over the first 30 min post-deploy