### PR TITLE
Pin prod LibreChat to v0.8.7-custom-v1 (203 + 666)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -37,7 +37,12 @@ image:
   registry: docker.io
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.8.3-rc1-custom-v9"
+  # v0.8.7-custom-v1: rebase of our v0.8.3-rc1-custom-v9 customizations
+  # onto upstream v0.8.7. Brings agents-lib 3.2.46 with Bedrock
+  # cachePoint wiring (unlocks Bedrock prompt caching — see
+  # model_parameters.promptCache: true on the prod agent records) +
+  # ~860 upstream commits worth of fixes. Beta soaked 2026-08-07.
+  tag: "v0.8.7-custom-v1"
 
 mongodb:
   enabled: false

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/values.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioagent/values.yaml
@@ -24,7 +24,12 @@ image:
   registry: docker.io
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.8.3-rc1-custom-v9"
+  # v0.8.7-custom-v1: rebase of our v0.8.3-rc1-custom-v9 customizations
+  # onto upstream v0.8.7. Brings agents-lib 3.2.46 with Bedrock
+  # cachePoint wiring (unlocks Bedrock prompt caching — see
+  # model_parameters.promptCache: true on the prod agent records) +
+  # ~860 upstream commits worth of fixes. Beta soaked 2026-08-07.
+  tag: "v0.8.7-custom-v1"
 
 mongodb:
   enabled: false


### PR DESCRIPTION
## Summary

Flip prod LibreChat image tag on **both accounts** from \`v0.8.3-rc1-custom-v9\` to **\`v0.8.7-custom-v1\`**. Two files, one line each.

Follow-up to knowledgesystems/knowledgesystems-k8s-deployment#542 which shipped the same tag to beta.

## Beta bake result (2026-08-07)

Live 3-turn conversation with 17 tool-call rounds cost **\$0.19** total. Uncached equivalent (~55k avg × 17 rounds × \$3/M input) would have been **~\$2.80 just for input** — ~65-70% cost reduction on this workload. Cache markers verified present in the outgoing Bedrock Converse payload; \`totalTokens\` includes cache_read tokens even though LibreChat's Bedrock instrumentation buckets them differently than Anthropic-direct in Langfuse.

No crashes, no 5xx spike, chat responses render correctly.

## Post-merge steps (manual, I'll do them)

Once Argo syncs and the pods roll:

1. **203 prod:** \`db.agents.updateMany({id: {\$in: ["agent_9ZXhcwLIsROBQX0u4JS5F","agent_4QP14nOYaCTkqK8E3Nopg"]}}, {\$set: {"model_parameters.promptCache": true}})\`
2. **666 prod:** \`db.agents.updateMany({id: {\$in: ["agent_5WYyS_-SMUJr4lkruXiEg","agent_oIst1kHNOyG1t80yue8wY","agent_4i4gYIOFpExz3IukT_ets","agent_yYHARfjOd7XL-QM0rkcSP"]}}, {\$set: {"model_parameters.promptCache": true}})\`

Without those flips, agents will run on the new image but not use caching. With them, the beta-verified pattern activates.

## Known post-rebase gaps

Called out for tracking; not blockers for this PR:
- **Reasoning-actions toggle** (Foris PR #28) — needs re-implementation on top of upstream's rewritten Part/Reasoning/Thinking/ToolCall components. May be partly obviated by upstream's own \`Claude Opus 4.7 Reasoning Visibility\` (v0.8.5). Users won't see the lightbulb until then.
- **Context summarization for agents** — upstream removed \`handleContextStrategy\` from BaseClient; needs re-implementation.

## Test plan

- [ ] Argo syncs cbioagent on both accounts cleanly (values.yaml only)
- [ ] Pods restart on new image without crash loops
- [ ] Mongo flip completes for all 6 agents
- [ ] Smoke chat on https://chat.cbioportal.org/ (cBioChat) — non-zero cache tokens in the next Langfuse AgentRun
- [ ] Smoke chat on https://chat.cbioportal.aws.mskcc.org/ (cBioDBAgent) — same
- [ ] No 5xx spike over the first 30 min

## Rollback

Revert this PR + one-line mongo undo. Reverts to \`v0.8.3-rc1-custom-v9\`, pods re-pull, agents stay functional (promptCache field is a no-op on the older image).