### PR TITLE
Add trailing slash to clickhouse-mcp URL (v0.8.7 SSRF fix)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -102,7 +102,8 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        url: http://cbioagent-clickhouse-mcp:80/db/mcp
+        # Trailing slash avoids FastMCP's 307 that LibreChat v0.8.7+ blocks as SSRF.
+        url: http://cbioagent-clickhouse-mcp:80/db/mcp/
         headers:
           x-user-id: "{{LIBRECHAT_USER_ID}}"
           x-user-email: "{{LIBRECHAT_USER_EMAIL}}"

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -110,7 +110,8 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        url: http://cbioagent-clickhouse-mcp:80/db/mcp
+        # Trailing slash avoids FastMCP's 307 that LibreChat v0.8.7+ blocks as SSRF.
+        url: http://cbioagent-clickhouse-mcp:80/db/mcp/
         headers:
           x-user-id: "{{LIBRECHAT_USER_ID}}"
           x-user-email: "{{LIBRECHAT_USER_EMAIL}}"


### PR DESCRIPTION
LibreChat v0.8.7 blocks redirects to private/reserved IPs as SSRF hardening. FastMCP mounted at /db/mcp issues a 307 to /db/mcp/ which the SSRF check refuses (in-cluster ClusterIP is a private IP). Adding the trailing slash to the configured URL skips the redirect. Applies to prod + beta on 203. Paired with knowledgesystems/portal-configuration#46 for 666.