### PR TITLE
Rate-limit secondary hosts (master/beta/staging) via shared Ingress (follow-up to #545)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-ingress.yml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-ingress.yml
@@ -5,7 +5,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/ingress.class: traefik
     kubernetes.io/tls-acme: "true"
-    traefik.ingress.kubernetes.io/router.middlewares: default-ipblock@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: default-ipblock@kubernetescrd,default-ratelimit-host@kubernetescrd
     acme.cert-manager.io/http01-ingress-class: traefik
   labels:
     app.kubernetes.io/instance: cbioportal

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/traefik/ratelimit-host-middleware.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/traefik/ratelimit-host-middleware.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ratelimit-host
+  namespace: default
+spec:
+  # Generous whole-host per-client-IP rate limit for secondary hosts
+  # (master/beta/staging) that share an annotation-based Ingress and so cannot
+  # path-scope a middleware. Set well above a normal page load (a study view
+  # fires many API calls) but far below bulk scraping. Tune as needed.
+  rateLimit:
+    average: 600 # ~600 requests / minute / client IP
+    period: 1m
+    burst: 100


### PR DESCRIPTION
Follow-up to #545 (rate-limit for `www.cbioportal.org`), which merged before the master change landed.

`master.cbioportal.org` receives the same bulk-scraper traffic (clients faking browser UAs). It shares an **annotation-based Ingress** (`cbio-ingress.yml`, with `beta`/`staging`) whose middleware can't be path-scoped like the www IngressRoute.

Rather than restructure master into its own IngressRoute (+cert, +swap-safety concerns), this adds a **generous whole-host per-IP rate limit** — a new `ratelimit-host` middleware (600/min, burst 100) attached to the shared annotation. That's well above a normal page load (a study view fires many API calls) but far below bulk scraping, so it protects `master`/`beta`/`staging` without affecting browsing. Numbers are tunable.

**Deploy note:** `ratelimit-host` lives in `apps/traefik` (manual-sync). Sync the `traefik` Argo app so the middleware exists before/as the auto-synced annotation reference resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
