### PR TITLE
Deploy clinical-events OOM fix to public backend (master-web-shenandoah)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal_backend_public_api_blue.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal_backend_public_api_blue.yaml
@@ -275,7 +275,7 @@ spec:
             - secretRef:
                 name: cbioportal-public-blue
           # Please change this in tandem with the website backend image.
-          image: cbioportal/cbioportal:demo-robots-txt-web-shenandoah
+          image: cbioportal/cbioportal:master-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 5

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal_backend_public_api_green.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal-api/cbioportal_backend_public_api_green.yaml
@@ -275,7 +275,7 @@ spec:
             - secretRef:
                 name: cbioportal-public-green
           # Please change this in tandem with the website backend image.
-          image: cbioportal/cbioportal:demo-robots-txt-web-shenandoah
+          image: cbioportal/cbioportal:master-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 5

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_blue.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_blue.yaml
@@ -278,7 +278,7 @@ spec:
             - secretRef:
                 name: cbioportal-public-blue
           # Please change this in tandem with the public API backend image.
-          image: cbioportal/cbioportal:demo-robots-txt-web-shenandoah
+          image: cbioportal/cbioportal:master-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 5

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_green.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbioportal_backend_public_green.yaml
@@ -278,7 +278,7 @@ spec:
             - secretRef:
                 name: cbioportal-public-green
           # Please change this in tandem with the public API backend image.
-          image: cbioportal/cbioportal:demo-robots-txt-web-shenandoah
+          image: cbioportal/cbioportal:master-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 5


### PR DESCRIPTION
Repoints the **public** and **public-api** backends (both **blue** and **green**) from `demo-robots-txt-web-shenandoah` → `master-web-shenandoah`, to deploy the study-wide clinical-events `pageSize` cap (cBioPortal/cbioportal#12287) that stops the public OOM crash-loop.

Both colors are updated so the fix survives the next blue/green swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
