### PR TITLE
Remove discrete-copy-number/fetch from www rate-limit (fix oncoprint 429s)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-www-ingressroute.yml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioportal/cbio-www-ingressroute.yml
@@ -9,9 +9,9 @@ spec:
   entryPoints:
     - websecure
   routes:
-    # Expensive bulk-data endpoints (browser UA): add per-IP rate limit
+    # Study-wide clinical-events (bulk/API only; the UI does not call this): per-IP rate limit
     - match: >-
-        Host(`www.cbioportal.org`) && HeaderRegexp(`User-Agent`, `Mozilla`) && !HeaderRegexp(`User-Agent`, `(?i)(headless|kprofile-pipeline)`) && (PathRegexp(`^/api/studies/[^/]+/clinical-events`) || PathRegexp(`^/api/molecular-profiles/[^/]+/discrete-copy-number/fetch`))
+        Host(`www.cbioportal.org`) && HeaderRegexp(`User-Agent`, `Mozilla`) && !HeaderRegexp(`User-Agent`, `(?i)(headless|kprofile-pipeline)`) && PathRegexp(`^/api/studies/[^/]+/clinical-events`)
       kind: Rule
       priority: 200
       middlewares:
@@ -22,9 +22,9 @@ spec:
       services:
         - name: cbioportal-backend-public-green
           port: 80
-    # Expensive bulk-data endpoints (non-browser): add per-IP rate limit
+    # Study-wide clinical-events (non-browser): per-IP rate limit
     - match: >-
-        Host(`www.cbioportal.org`) && (PathRegexp(`^/api/studies/[^/]+/clinical-events`) || PathRegexp(`^/api/molecular-profiles/[^/]+/discrete-copy-number/fetch`))
+        Host(`www.cbioportal.org`) && PathRegexp(`^/api/studies/[^/]+/clinical-events`)
       kind: Rule
       priority: 190
       middlewares:


### PR DESCRIPTION
## Fixes: legitimate portal usage getting 429'd

A normal multi-study **oncoprint** (e.g. 32-study pan-cancer view for one gene) fires **~one small `discrete-copy-number/fetch` per study in a burst** (~32 requests). Our `ratelimit-heavy` middleware (50/min, burst 20 per IP, added in #545) was scoped to *both* `clinical-events` **and** `discrete-copy-number/fetch`, so those bursts trip the limit and 429 real users mid-oncoprint.

Example that reproduces: `www.cbioportal.org/results/oncoprint?cancer_study_list=<32 TCGA studies>&gene_list=EGFR&...` → each study fires `POST …/discrete-copy-number/fetch` with `{entrezGeneIds:[1956], sampleListId:"…_all"}`.

## Change

Scope the rate-limit to **study-wide `clinical-events` only** and drop `discrete-copy-number/fetch`:
- The OOM this was interim relief for is now **fixed at the source** — the clinical-events `pageSize` cap (cBioPortal/cbioportal#12287) is deployed and the public backend has been stable.
- The CNA endpoint is a POST already **bounded by its request body** (`entrezGeneIds` max 50,000), so it was never the unbounded-default problem clinical-events was, and doesn't need rate-limiting.
- `clinical-events` stays rate-limited and is safe — the UI never calls the study-wide endpoint (0 frontend call sites); it's bulk/API only.

Once merged, the `cbioportal` app (`selfHeal`) rolls it out and the CNA 429s stop.
