### PR TITLE
Fix wrong OIDC provider output reference in ACGC's iam module

### DIFF
--- a/iac/aws/175678591974/clusters/oncokb-research/eks/main.tf
+++ b/iac/aws/175678591974/clusters/oncokb-research/eks/main.tf
@@ -292,7 +292,13 @@ module "eks_cluster" {
 }
 
 module "iam" {
-  source                    = "../iam"
-  cluster_oidc_provider_arn = module.eks_cluster.cluster_oidc_provider
+  source = "../iam"
+  # module.eks_cluster.cluster_oidc_provider doesn't exist on this module
+  # version (4.0.0) — that name only appears (also incorrectly) in
+  # 203403084713's eks/main.tf; oidc_provider is what 4.0.0 actually
+  # exports (bare issuer hostname, matching what iam/'s trust-policy
+  # condition key expects — see 666628074417's eks/main.tf for the same
+  # correct usage).
+  cluster_oidc_provider_arn = module.eks_cluster.oidc_provider
   cluster_name              = basename(module.eks_cluster.cluster_arn)
 }


### PR DESCRIPTION
## Summary
`module "iam"` in `eks/main.tf` referenced `module.eks_cluster.cluster_oidc_provider`, which doesn't exist on the pinned `eks_cluster` module version (`4.0.0`) — confirmed directly against the downloaded module source, which only exports `cluster_oidc_issuer_url`, `oidc_provider`, and `oidc_provider_arn`.

The wrong name was copied from `203403084713`'s `eks/main.tf`, which has the same incorrect reference (untested/unapplied since that account's own `module "iam"` predates this pattern, presumably). `666628074417`'s `eks/main.tf` already correctly uses `oidc_provider`.

Caught while running `terraform plan` for [PR #540](https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/pull/540)'s `iam/` module — blocked the ACGC Bedrock-refresher IAM role from ever being created.

## Test plan
- [x] Confirmed real output names by inspecting the actual downloaded `eks_cluster` module source (`.terraform/modules/eks_cluster/outputs.tf`) after `terraform init`
- [ ] `terraform plan` succeeds past this point (in progress by @ForisKuang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)