### PR TITLE
Revert ACGC image reference to Docker Hub

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
@@ -25,9 +25,8 @@ spec:
       annotations:
         admission.datadoghq.com/python-lib.version: v3
     spec:
-      # No imagePullSecrets: CI publishes this image to GHCR (not Docker
-      # Hub, unlike every other app here), and the package is public, so
-      # no pull credential is needed.
+      imagePullSecrets:
+        - name: oncokb-dockerhub-creds
       #
       # No serviceAccountName/IRSA here: Bedrock lives in a separate AWS
       # account (490004633549, where the org's Bedrock credits are
@@ -40,7 +39,7 @@ spec:
       # actually picked up (matches cell-explorer's identical setup).
       containers:
         - name: agentic-cancer-gene-classification
-          image: ghcr.io/oncokb/agentic-cancer-gene-classification:latest
+          image: oncokb/agentic-cancer-gene-classification:latest
           imagePullPolicy: Always
           ports:
             - name: http


### PR DESCRIPTION
## Summary
Switches the Deployment back to `image: oncokb/agentic-cancer-gene-classification:latest` with `imagePullSecrets: oncokb-dockerhub-creds` restored.

Context: PR #540 originally referenced this image via Docker Hub, but I switched it to GHCR mid-review after discovering CI only published there. Turns out that CI job (auto-publish on merge to `main`) isn't actually this org's intended production publish path — the real pattern is a release-triggered Docker Hub push, matching [oncokb-public](https://github.com/oncokb/oncokb-public/blob/master/.github/workflows/docker-sentry-release.yml). See [oncokb/agentic-cancer-gene-classification#45](https://github.com/oncokb/agentic-cancer-gene-classification/pull/45) for the new workflow that publishes there.

## Still open
- Nothing publishes to `oncokb/agentic-cancer-gene-classification` on Docker Hub until a maintainer actually publishes a GitHub Release on the app repo (triggers the new workflow linked above).
- Confirm `oncokb-dockerhub-creds` (already used by every other app in this cluster) has pull access to this specific Docker Hub repo once an image exists there.

## Test plan
- [x] YAML validated (`yaml.safe_load_all`, multi-document Deployment+Service file)
- [ ] Live image pull not yet verified — blocked on the release being published

🤖 Generated with [Claude Code](https://claude.com/claude-code)