### PR TITLE
Drop ACGC's imagePullSecrets — image is public, no credential needed

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
@@ -25,8 +25,11 @@ spec:
       annotations:
         admission.datadoghq.com/python-lib.version: v3
     spec:
-      imagePullSecrets:
-        - name: oncokb-dockerhub-creds
+      # No imagePullSecrets: the image is public, so no pull credential is
+      # needed. Left commented out below rather than removed, in case this
+      # repo's visibility changes later:
+      # imagePullSecrets:
+      #   - name: oncokb-dockerhub-creds
       #
       # No serviceAccountName/IRSA here: Bedrock lives in a separate AWS
       # account (490004633549, where the org's Bedrock credits are


### PR DESCRIPTION
## Summary
`oncokb/agentic-cancer-gene-classification` is a public Docker Hub image — confirmed via `docker pull oncokb/agentic-cancer-gene-classification:latest` succeeding anonymously, no login needed. A pull secret isn't required to pull a public image, so this removes `imagePullSecrets` from the Deployment.

Left commented out rather than deleted, in case this repo's visibility ever changes and a pull secret becomes necessary again.

## Test plan
- [x] YAML validated
- [ ] Pod pulls successfully and reaches `Running` after this merges + syncs (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)