### PR TITLE
Cap public 203 balance at 5M tokens/week

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -139,11 +139,19 @@ data:
 
     balance:
       enabled: true
-      startBalance: 20000000
+      # 5M tokens/week ≈ $25/user/week ceiling under Sonnet 5 standard
+      # pricing (post-Sept 1), ~$8/user/week under promo. Observed peak
+      # single-user weekly spend historically was ~$22 (Gisetia, 2026-06),
+      # so this cap won't bite legitimate use but keeps a single runaway
+      # user from making a dent even at scale.
+      # NOTE: this only affects NEW users. Existing 458 users have their
+      # own refillAmount baked into balances collection docs — a one-time
+      # mongo updateMany is required alongside this deploy.
+      startBalance: 5000000
       autoRefillEnabled: true
       refillIntervalValue: 7
       refillIntervalUnit: "days"
-      refillAmount: 20000000
+      refillAmount: 5000000
 
     # Unified single-agent spec. The previous cBioDBAgent
     # (agent_4QP14nOYaCTkqK8E3Nopg) and cBioNavigator


### PR DESCRIPTION
Drop `startBalance` and `refillAmount` from 20M → 5M on the public 203 librechat-config. Companion mongo update on the balances collection follows deploy.

## Why

- Chat link merged into cbioportal-frontend (2026-08-11); more traffic incoming, want a tighter per-user ceiling
- Historical peak single-user weekly spend was $22 (Gisetia, 2026-06 under old Sonnet 4.6 uncached — the tightest regime, ~$20 cap). Nobody has exceeded that.
- 20M is loose today: under Sonnet 5 promo it allows ~$33/user/week; under standard $99/user/week

## Ceilings at new cap

| Model regime | New $-ceiling per user per week |
|---|---|
| Sonnet 5 promo (now, through Aug 31) | ~$8 |
| Sonnet 5 standard (Sept 1+) | ~$25 |
| Sonnet 4.6 uncached (historic reference) | ~$5 |

## Companion mongo update (not in this PR)

458 existing users have their own `refillAmount` baked into balance docs (this config only sets defaults for NEW users). After Argo syncs this:
```js
db.balances.updateMany({}, {
  $set: {refillAmount: 5000000},
  $min: {tokenCredits: 5000000}
});
```
I'll run that once this merges + syncs.

## Rollback

Revert this PR + mongo updateMany to restore refillAmount to 20M. Users' capped tokenCredits are lost (can't un-clip below the cap), but they'll refill to 20M on next interval.