### PR TITLE
cbioagent-beta: point at mcp-apps MCP for ui:// widget preview

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -15,6 +15,7 @@ data:
     mcpSettings:
       allowedDomains:
         - 'cbioagent-clickhouse-mcp'
+        - 'cbioagent-clickhouse-mcp-apps'
         - 'cbioportal-navigator'
         - 'cbioportal-navigator-beta'
 
@@ -102,8 +103,13 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        # Trailing slash avoids FastMCP's 307 that LibreChat v0.8.7+ blocks as SSRF.
-        url: http://cbioagent-clickhouse-mcp:80/db/mcp/
+        # Beta points at the mcp-apps image (feature/mcp-apps branch of
+        # cbioportal-mcp). Superset of the main MCP: all original SQL tools
+        # plus widget-returning tools (survival, oncoprint, lollipop,
+        # co-occurrence, generic charts) as ui:// resources rendered by
+        # LibreChat's MCP-UI pipeline. Trailing slash avoids FastMCP's 307
+        # that LibreChat v0.8.7+ blocks as SSRF.
+        url: http://cbioagent-clickhouse-mcp-apps:80/db-mcp-apps/mcp/
         headers:
           x-user-id: "{{LIBRECHAT_USER_ID}}"
           x-user-email: "{{LIBRECHAT_USER_EMAIL}}"


### PR DESCRIPTION
## Summary

- Swap beta LibreChat's `cbioportal-database` MCP URL from `cbioagent-clickhouse-mcp` → `cbioagent-clickhouse-mcp-apps` (feature/mcp-apps branch of `cbioportal-mcp`).
- Superset: all original SQL tools **plus** widget-returning tools (survival, oncoprint, lollipop, co-occurrence, generic pie/bar/line charts) that emit `ui://` resources rendered inline by LibreChat v0.8.7's MCP-UI pipeline.
- Prod remains on the main MCP.

## Why

`cbioagent-clickhouse-mcp-apps` Deployment + Service + Ingress are already live (image `cbioportal/mcp:mcp-apps`, exposed at `https://mcp.cbioportal.org/db-mcp-apps/mcp`). This is purely a config wire-up so beta users can trial in-chat widgets while we validate them against the gap-analysis test set from cbioportal/cbioportal-mcp's `docs/mcp-apps-gap-analysis.md`.

## Test plan

- [ ] Argo sync `cbioagent-beta` App.
- [ ] Confirm Reloader rolls `cbioagent-librechat-beta` Deployment.
- [ ] `kubectl exec deploy/cbioagent-librechat-beta -- printenv | grep MCP` (sanity) and hit `beta.chat.cbioportal.org` — start a new chat, ask for an OncoPrint or KM plot, verify a `ui://` widget renders inline (LibreChat `\ui{...}` marker resolved).
- [ ] Sanity: existing SQL tool paths (`run_select_query`, `list_studies`, etc.) still work — the mcp-apps image is a superset so nothing should regress.
- [ ] Watch Langfuse for any tool-call errors from the new widget tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj