### PR TITLE
cbioagent-beta: drop trailing slash from mcp-apps URL (fix init failure)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -107,9 +107,14 @@ data:
         # cbioportal-mcp). Superset of the main MCP: all original SQL tools
         # plus widget-returning tools (survival, oncoprint, lollipop,
         # co-occurrence, generic charts) as ui:// resources rendered by
-        # LibreChat's MCP-UI pipeline. Trailing slash avoids FastMCP's 307
-        # that LibreChat v0.8.7+ blocks as SSRF.
-        url: http://cbioagent-clickhouse-mcp-apps:80/db-mcp-apps/mcp/
+        # LibreChat's MCP-UI pipeline.
+        #
+        # No trailing slash — FastMCP 3.3.1 (this image) serves 200 on
+        # `.../mcp` and 307 → `.../mcp` on `.../mcp/`, i.e. the OPPOSITE
+        # of the older FastMCP on the main MCP. LibreChat v0.8.7's SSRF
+        # hardening blocks the private-IP redirect either way, so match
+        # whichever URL doesn't redirect.
+        url: http://cbioagent-clickhouse-mcp-apps:80/db-mcp-apps/mcp
         headers:
           x-user-id: "{{LIBRECHAT_USER_ID}}"
           x-user-email: "{{LIBRECHAT_USER_EMAIL}}"


### PR DESCRIPTION
## Summary

Follow-up to #554. The mcp-apps MCP failed to initialize because I set the URL with a trailing slash — but **FastMCP 3.3.1 (the mcp-apps image) mounts opposite to the older FastMCP on the main MCP**: 200 on no-slash, 307 on trailing slash. LibreChat v0.8.7's SSRF hardening blocks the private-IP redirect, so init dies.

Verified externally against `https://mcp.cbioportal.org/db-mcp-apps/mcp`:

```
POST /db-mcp-apps/mcp  → 200 (real MCP initialize response, tools/capabilities/etc.)
POST /db-mcp-apps/mcp/ → 307 Location: /db-mcp-apps/mcp
```

Drops the trailing slash in the beta config so the request lands on the canonical URL directly.

## Test plan

- [ ] Argo sync `cbioagent-beta`, Reloader rolls `cbioagent-librechat-beta`.
- [ ] Beta chat surfaces the mcp-apps tools (survival, oncoprint, lollipop, co-occurrence, generic charts) alongside the existing SQL tools.
- [ ] `list_tools` from the LibreChat side shows the new widget-returning tools without an "MCP initialization failed" error.
- [ ] Ask for an OncoPrint or KM plot on beta and confirm a `ui://` widget renders inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj