### PR TITLE
cbioagent-beta: track v0.8.7-mcp-ui-meta for MCP-Apps widget rendering

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -96,14 +96,17 @@ image:
   repository: cbioportal/librechat
   registry: docker.io
   pullPolicy: Always
-  # Beta pinned to the v0.8.7 rebase for validation. Built from the
-  # v0.8.7-custom-v1 branch on cbioportal/librechat (rebase of our
-  # v0.8.3-rc1-custom-v9 customizations on top of upstream v0.8.7 —
-  # brings agents-lib 3.2.46 with Bedrock cachePoint wiring, ~860
-  # upstream commits worth of fixes). Once soaked on beta we roll to
-  # prod under the same tag scheme. Keel still watches the tag digest;
-  # a re-push to v0.8.7-custom-v1 would still roll this pod.
-  tag: "v0.8.7-custom-v1"
+  # Beta tracks the v0.8.7-mcp-ui-meta feature branch tag on
+  # cbioportal/librechat — a superset of v0.8.7-custom-v1 that adds the
+  # MCP-Apps shim (packages/api/src/mcp/mcpAppsShim.ts + connection
+  # `_meta.ui.resourceUri` cache) so widgets from fastmcp>=3.3.1 MCP
+  # servers render inline. Needed to actually see the cbioportal-mcp
+  # feature/mcp-apps widgets (survival, oncoprint, lollipop, etc.) on
+  # beta. See cbioportal/librechat#35. Once soaked, cut a
+  # `v0.8.7-custom-v2` tag from the merged branch and move prod +
+  # beta over to it. Keel watches the tag digest, so re-pushing this
+  # branch (further iteration on the shim) auto-rolls beta.
+  tag: "v0.8.7-mcp-ui-meta"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:


### PR DESCRIPTION
## Summary

Point beta's LibreChat image at `cbioportal/librechat:v0.8.7-mcp-ui-meta` — a superset of `v0.8.7-custom-v1` that adds the MCP-Apps compatibility shim from cbioportal/librechat#35.

The shim lets LibreChat render widgets from fastmcp>=3.3.1 MCP servers, which declare their widget URI on the tool via `_meta.ui.resourceUri` (and return tool responses with only structured data) rather than emitting a `resource` content part per response — the flavor LibreChat currently parses.

Required to actually see the cbioportal-mcp `feature/mcp-apps` widgets (survival, oncoprint, lollipop, co-occurrence, generic charts) that we wired beta up to in #554/#555.

## Scope

- **Beta only.** Prod (203 + 666) stays on `v0.8.7-custom-v1` until we cut a `v0.8.7-custom-v2` tag from the merged shim and soak beta.
- Tag is branch-tracking (`v0.8.7-mcp-ui-meta`), so any further iteration on the shim will re-push the tag and Keel will auto-roll beta.

## Test plan

- [ ] Argo sync `cbioagent-beta`; Keel or Reloader rolls the pod.
- [ ] `kubectl exec deploy/cbioagent-librechat-beta -- printenv | grep -i tag` (sanity) — image digest matches new tag.
- [ ] On beta.chat.cbioportal.org, ask for an OncoPrint or KM plot against the mcp-apps MCP; confirm a widget renders inline (rather than raw JSON tool output).
- [ ] Regression check on non-widget tools (`list_studies`, `run_select_query`, etc.) — should still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj