### PR TITLE
cbioagent-beta: revert MCP-Apps widget experiment

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/librechat-config.yaml
@@ -15,7 +15,6 @@ data:
     mcpSettings:
       allowedDomains:
         - 'cbioagent-clickhouse-mcp'
-        - 'cbioagent-clickhouse-mcp-apps'
         - 'cbioportal-navigator'
         - 'cbioportal-navigator-beta'
 
@@ -103,18 +102,8 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        # Beta points at the mcp-apps image (feature/mcp-apps branch of
-        # cbioportal-mcp). Superset of the main MCP: all original SQL tools
-        # plus widget-returning tools (survival, oncoprint, lollipop,
-        # co-occurrence, generic charts) as ui:// resources rendered by
-        # LibreChat's MCP-UI pipeline.
-        #
-        # No trailing slash — FastMCP 3.3.1 (this image) serves 200 on
-        # `.../mcp` and 307 → `.../mcp` on `.../mcp/`, i.e. the OPPOSITE
-        # of the older FastMCP on the main MCP. LibreChat v0.8.7's SSRF
-        # hardening blocks the private-IP redirect either way, so match
-        # whichever URL doesn't redirect.
-        url: http://cbioagent-clickhouse-mcp-apps:80/db-mcp-apps/mcp
+        # Trailing slash avoids FastMCP's 307 that LibreChat v0.8.7+ blocks as SSRF.
+        url: http://cbioagent-clickhouse-mcp:80/db/mcp/
         headers:
           x-user-id: "{{LIBRECHAT_USER_ID}}"
           x-user-email: "{{LIBRECHAT_USER_EMAIL}}"

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent-beta/values.yaml
@@ -96,17 +96,14 @@ image:
   repository: cbioportal/librechat
   registry: docker.io
   pullPolicy: Always
-  # Beta tracks the v0.8.7-mcp-ui-meta feature branch tag on
-  # cbioportal/librechat — a superset of v0.8.7-custom-v1 that adds the
-  # MCP-Apps shim (packages/api/src/mcp/mcpAppsShim.ts + connection
-  # `_meta.ui.resourceUri` cache) so widgets from fastmcp>=3.3.1 MCP
-  # servers render inline. Needed to actually see the cbioportal-mcp
-  # feature/mcp-apps widgets (survival, oncoprint, lollipop, etc.) on
-  # beta. See cbioportal/librechat#35. Once soaked, cut a
-  # `v0.8.7-custom-v2` tag from the merged branch and move prod +
-  # beta over to it. Keel watches the tag digest, so re-pushing this
-  # branch (further iteration on the shim) auto-rolls beta.
-  tag: "v0.8.7-mcp-ui-meta"
+  # Beta pinned to the v0.8.7 rebase for validation. Built from the
+  # v0.8.7-custom-v1 branch on cbioportal/librechat (rebase of our
+  # v0.8.3-rc1-custom-v9 customizations on top of upstream v0.8.7 —
+  # brings agents-lib 3.2.46 with Bedrock cachePoint wiring, ~860
+  # upstream commits worth of fixes). Once soaked on beta we roll to
+  # prod under the same tag scheme. Keel still watches the tag digest;
+  # a re-push to v0.8.7-custom-v1 would still roll this pod.
+  tag: "v0.8.7-custom-v1"
 
 # Sub-charts: all disabled. Beta shares prod's backend services.
 mongodb:


### PR DESCRIPTION
## Summary

Rolls beta back to prod's baseline pending upstream LibreChat MCP-Apps support:

- **Image tag**: `v0.8.7-mcp-ui-meta` → `v0.8.7-custom-v1` (drops the shim + mcp-ui-client bump). The shim work stays alive as cbioportal/librechat#35 in case we want to revisit.
- **`cbioportal-database` MCP URL**: back to the main `cbioagent-clickhouse-mcp` Deployment (SQL tools + Navigator; no widget tools).
- Drops `cbioagent-clickhouse-mcp-apps` from `mcpSettings.allowedDomains`.

## Why

The widget-rendering path needed either (a) a large client-side refactor of LibreChat's MCP-UI integration (v6+/`AppRenderer` + sandbox proxy + browser-side MCP client) or (b) a downgrade of the widget bundles' embedded `mcp-ui-server` version — the former is a real refactor, the latter breaks Claude Desktop interop.

Upstream already has [danny-avila/LibreChat#13831](https://github.com/danny-avila/LibreChat/pull/13831) doing this properly (adopts the official `@modelcontextprotocol/ext-apps` SDK, includes a sandbox proxy, tool visibility gating, path-traversal guards, per-request `mcpSettings.apps` toggle). Rebasing `v0.8.7-custom-v1` onto whatever release includes that PR will land it cleanly; a from-scratch cherry-pick tonight produced a 25-conflict merge that I don't want to babysit on beta.

## Scope

Beta only. Prod (203 + 666) was untouched throughout; this simply returns beta to that same working baseline.

## Test plan

- [ ] Argo sync `cbioagent-beta`; Reloader rolls the pod on the ConfigMap change.
- [ ] Keel/Argo rolls the Deployment on the tag change; new pod pulls `v0.8.7-custom-v1` digest.
- [ ] Beta chat surfaces normal SQL tools + Navigator, no more "Unsupported resource type" / stuck-loading widgets.
- [ ] Quick smoke: `list_studies`, `run_select_query` still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj