### PR TITLE
cbioagent: add auth-protected /db-auth/mcp variant (Google OAuth)

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cbioagent-clickhouse-mcp-auth
+  labels:
+    run: cbioagent-clickhouse-mcp-auth
+  annotations:
+    # Reloader rolls this Deployment when the daily clone cron patches
+    # clickhouse-mcp-active.CLICKHOUSE_DATABASE on a successful build,
+    # and when the Google OAuth client credentials rotate.
+    configmap.reloader.stakater.com/reload: "clickhouse-mcp-active"
+    secret.reloader.stakater.com/reload: "cbioportal-mcp-google-oauth"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: cbioagent-clickhouse-mcp-auth
+  template:
+    metadata:
+      labels:
+        run: cbioagent-clickhouse-mcp-auth
+    spec:
+      containers:
+        - name: cbioagent-clickhouse-mcp
+          # Google OAuth variant of the DB MCP — cbioportal-mcp#107
+          # (feat/mcp-google-oauth branch). All the same SQL tools +
+          # study guides as the main MCP; adds FastMCP's GoogleProvider
+          # so direct MCP connectors (Claude Desktop, Claude Code,
+          # claude.ai) authenticate via Google before any tool call.
+          # Deliberately kept as its own Deployment: the internal
+          # `cbioagent-clickhouse-mcp` LibreChat talks to stays
+          # unauthenticated so we don't disturb existing traffic.
+          image: cbioportal/mcp:mcp-google-oauth
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          env:
+            # Node-local Datadog agent IP exposed via Downward API.
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_SERVICE_NAME
+              value: "cbioportal-mcp-auth"
+            - name: DD_LLMOBS_ML_APP
+              value: "cbioportal-mcp-auth"
+            - name: DD_SITE
+              value: "datadoghq.com"
+            # Mount FastMCP under the external sub-path so trailing-slash
+            # redirects point to https://mcp.cbioportal.org/db-auth/mcp/
+            # rather than /mcp/. Paired with NOT stripping /db-auth on
+            # the mcp-cbioportal-db-auth-ingress Ingress.
+            - name: CLICKHOUSE_MCP_HTTP_PATH
+              value: "/db-auth/mcp"
+            # Trust X-Forwarded-* from any in-cluster source so uvicorn's
+            # 307 trailing-slash redirect honors Traefik's
+            # X-Forwarded-Proto: https. Same reasoning as the sibling
+            # unauthenticated MCP Deployments.
+            - name: CLICKHOUSE_MCP_FORWARDED_ALLOW_IPS
+              value: "*"
+          envFrom:
+            - secretRef:
+                name: clickhouse-mcp
+            # Google OAuth client — the presence of all three
+            # CBIOPORTAL_MCP_GOOGLE_* env vars flips the server into
+            # authenticated mode (see cbioportal-mcp auth.py). Lives in
+            # portal-configuration since it holds secrets.
+            - secretRef:
+                name: cbioportal-mcp-google-oauth
+            # ConfigMap mounted AFTER the Secrets so its CLICKHOUSE_DATABASE
+            # value wins (envFrom: last-writer-wins on key collisions). The
+            # cbioagent-clickhouse-clone-daily CronJob owns this ConfigMap
+            # and updates it when the production color flips, then rolls
+            # this Deployment.
+            - configMapRef:
+                name: clickhouse-mcp-active
+      nodeSelector:
+        workload: "cbioagent"
+      tolerations:
+        - key: "workload"
+          operator: "Equal"
+          value: "cbioagent"
+          effect: "NoSchedule"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbioagent-clickhouse-mcp-auth
+spec:
+  selector:
+    run: cbioagent-clickhouse-mcp-auth
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8000
+  type: ClusterIP

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -89,6 +89,38 @@ spec:
         - mcp.cbioportal.org
       secretName: mcp-cbio-cert
 ---
+# /db-auth — Google-OAuth-protected variant of /db, backed by
+# cbioagent-clickhouse-mcp-auth. Same host + same TLS secret. The
+# path is NOT stripped — FastMCP is configured (via the
+# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp-auth)
+# to mount itself at /db-auth/mcp so trailing-slash redirects and the
+# GoogleProvider callback URL (/db-auth/auth/callback) build correctly.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-cbioportal-db-auth-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: default-ratelimit-db@kubernetescrd
+  labels:
+    app.kubernetes.io/instance: cbioagent
+spec:
+  rules:
+    - host: mcp.cbioportal.org
+      http:
+        paths:
+          - path: /db-auth
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - mcp.cbioportal.org
+      secretName: mcp-cbio-cert
+---
 # /db-mcp-apps — separate Ingress so its own rate-limit middleware only applies
 # here. Same host + same TLS secret; Traefik merges Ingress rules per
 # host. The path is NOT stripped — FastMCP is configured (via the


### PR DESCRIPTION
## Summary

New sibling MCP Deployment for the cbioportal-mcp `feat/mcp-google-oauth` branch (per cBioPortal/cbioportal-mcp#107). Serves the same SQL tools + study guides as the main MCP, but FastMCP's `GoogleProvider` requires a Google login before any tool call — so direct MCP connectors (Claude Desktop, Claude Code, claude.ai's hosted connector) get a verified user identity.

- **`cbioagent-clickhouse-mcp-auth.yaml`** — Deployment + Service. Image `cbioportal/mcp:mcp-google-oauth` (already published by the CI dispatch on `main`). Mirrors the `-apps.yaml` shape: mounts FastMCP at `/db-auth/mcp`, envFroms the same `clickhouse-mcp` Secret + `clickhouse-mcp-active` ConfigMap for DB creds, PLUS the new `cbioportal-mcp-google-oauth` Secret which flips the server into authenticated mode. Reloader annotation auto-rolls on OAuth-secret rotation or DB-color flip.
- **`mcp-ingress.yaml`** — new Ingress rule for `mcp.cbioportal.org/db-auth` → the new Service, same `ratelimit-db` middleware as `/db`. Path NOT stripped so FastMCP's mount + GoogleProvider callback (`/db-auth/auth/callback`) resolve correctly.

## Why a separate Deployment

The internal `cbioagent-clickhouse-mcp` that LibreChat talks to stays unauthenticated — LibreChat already has its own auth in front and the header-based identity we pass (`x-user-id`) is enough for observability there. This new Deployment is for the *direct* connector use case where we currently have no identity signal at all.

## Requires

- knowledgesystems/portal-configuration#50 to be synced first (adds the `cbioportal-mcp-google-oauth` Secret this Deployment consumes).
- Google OAuth client already created; redirect URI `https://mcp.cbioportal.org/db-auth/auth/callback` registered.

## Test plan

- [ ] Merge portal-configuration#50 → Argo syncs Secret.
- [ ] Merge this PR → Argo syncs Deployment + Service + Ingress.
- [ ] `kubectl logs deploy/cbioagent-clickhouse-mcp-auth` shows `✅ Google OAuth enabled for client 376866430586-…`.
- [ ] `curl -sD - -o /dev/null https://mcp.cbioportal.org/db-auth/mcp` returns 401 with WWW-Authenticate.
- [ ] `curl -s https://mcp.cbioportal.org/db-auth/.well-known/oauth-authorization-server` returns OAuth metadata.
- [ ] Add `https://mcp.cbioportal.org/db-auth/mcp/` as a connector in Claude Desktop, complete Google login, list tools + run one query end-to-end.
- [ ] Existing `/db/mcp/` (unauthenticated, LibreChat-facing) and `/db-mcp-apps/mcp` (widgets) still work — sanity that they weren't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj