### PR TITLE
cbioagent: route root-level OAuth paths to auth Deployment

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -116,6 +116,70 @@ spec:
                 name: cbioagent-clickhouse-mcp-auth
                 port:
                   number: 80
+          # FastMCP's GoogleProvider registers all OAuth endpoints at
+          # the base_url ORIGIN, not under the MCP mount path — so the
+          # OAuth-plane routes below all live at root and need Ingress
+          # to forward them into the same Deployment. Enumerated
+          # against a probe FastMCP+GoogleProvider instance:
+          #   /.well-known/oauth-authorization-server (AS metadata)
+          #   /.well-known/oauth-protected-resource/... (resource metadata; suffix depends on mount path)
+          #   /authorize     (auth code request)
+          #   /token         (token exchange)
+          #   /register      (Dynamic Client Registration for MCP clients)
+          #   /consent       (host consent screen)
+          #   /auth/callback (Google -> us callback; MUST match the URI
+          #                  registered in Google Cloud Console for this client)
+          # These paths are otherwise unused on mcp.cbioportal.org — no
+          # other service on this host consumes them today.
+          - path: /.well-known/oauth-authorization-server
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+          - path: /.well-known/oauth-protected-resource
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+          - path: /authorize
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+          - path: /token
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+          - path: /register
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+          - path: /consent
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+          - path: /auth/callback
+            pathType: Prefix
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
   tls:
     - hosts:
         - mcp.cbioportal.org


### PR DESCRIPTION
## Summary

FastMCP's `GoogleProvider` registers its OAuth endpoints at the **`base_url` ORIGIN**, not under the MCP server's mount path. So `mcp.cbioportal.org/.well-known/oauth-authorization-server`, `/authorize`, `/token`, `/register`, `/consent`, `/auth/callback` all need to route to `cbioagent-clickhouse-mcp-auth` even though the MCP endpoint itself lives at `/db-auth/mcp`.

Enumerated live against a probe FastMCP+GoogleProvider instance:
```
GET  /.well-known/oauth-authorization-server
GET  /.well-known/oauth-protected-resource/db-auth/mcp
POST /authorize
POST /token
POST /register
POST /consent
GET  /auth/callback
```
None of those paths are otherwise used on `mcp.cbioportal.org` today.

## Companion PRs

- **knowledgesystems/portal-configuration#51** — sets `CBIOPORTAL_MCP_GOOGLE_BASE_URL` to the origin (not the mount path) so FastMCP builds the resource-metadata URL correctly.
- **Google Cloud Console** (manual): update the OAuth client's Authorized Redirect URIs from `https://mcp.cbioportal.org/db-auth/auth/callback` → `https://mcp.cbioportal.org/auth/callback`.

## Test plan

- [ ] Argo syncs Ingress; Traefik picks up new rules.
- [ ] `curl https://mcp.cbioportal.org/.well-known/oauth-authorization-server` returns AS metadata (was 404).
- [ ] `curl https://mcp.cbioportal.org/.well-known/oauth-protected-resource/db-auth/mcp` returns resource metadata.
- [ ] Claude Desktop full OAuth flow against `https://mcp.cbioportal.org/db-auth/mcp/` succeeds (Google login → consent → tools/list).
- [ ] Existing `/db/mcp/`, `/db-mcp-apps/mcp`, `/navigator` still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj