### PR TITLE
cbioagent-mcp-auth: add Keel annotations for tag-tracking auto-roll

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
@@ -10,6 +10,17 @@ metadata:
     # and when the Google OAuth client credentials rotate.
     configmap.reloader.stakater.com/reload: "clickhouse-mcp-active"
     secret.reloader.stakater.com/reload: "cbioportal-mcp-google-oauth"
+    # Track the mutable `cbioportal/mcp:mcp-google-oauth` tag — every
+    # push to the `mcp-google-oauth` branch on cbioportal/cbioportal-mcp
+    # (or explicit `workflow_dispatch` builds against it) overwrites that
+    # tag digest. Keel polls Docker Hub and rolls this Deployment when
+    # the digest behind the tag changes. Same pattern beta LibreChat uses;
+    # fine here because this Deployment is on a feature branch we're
+    # actively iterating on. Swap to a versioned tag when we cut a
+    # release.
+    keel.sh/policy: force
+    keel.sh/trigger: poll
+    keel.sh/match-tag: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary

Adds Keel annotations to `cbioagent-clickhouse-mcp-auth` so the pod auto-rolls when the mutable `cbioportal/mcp:mcp-google-oauth` tag digest changes on Docker Hub. Same pattern the beta LibreChat Deployment uses.

Without this, every image rebuild on that tag needs a manual `kubectl rollout restart` to pick up.

Fine while cbioportal-mcp#107 (feat/mcp-google-oauth) is still an iterative feature branch — swap to a versioned tag pin when the PR merges and we cut a stable release.

## Test plan

- [ ] Argo syncs the Deployment (annotation change; no pod restart from the annotation itself).
- [ ] Next re-push to `mcp-google-oauth` tag on Docker Hub → Keel rolls the pod within ~1 min.
- [ ] Existing SQL tool calls and Google OAuth flow keep working after the roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj