### PR TITLE
feat(cell-explorer): bump prod image to 0.5.0

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:sha-ea709af
+          image: ghcr.io/cbioportal/cell-explorer-py:0.5.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Bumps cell-explorer prod image `sha-ea709af` → `0.5.0` (`cell-explorer-api-v0.5.0`, released today).

## Ships
- **Collections** — backend model/endpoints (#177) + frontend catalog grouping (baked-in highperformer 0.5.3 / app 0.1.4).
- **Pluggable OIDC provider** (#175) — backward-compatible; existing `KEYCLOAK_*` config still honored (`auth_provider` defaults to `keycloak`), so no configmap change.

## Notes
- Collections adds a `Collection` table + `datasets.collection_id` column; the Alembic migration auto-runs on boot.
- No new config/secrets.