### PR TITLE
cbioagent: make public /db/mcp Google-OAuth-gated by default

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
@@ -57,12 +57,15 @@ spec:
               value: "cbioportal-mcp-auth"
             - name: DD_SITE
               value: "datadoghq.com"
-            # Mount FastMCP under the external sub-path so trailing-slash
-            # redirects point to https://mcp.cbioportal.org/db-auth/mcp/
-            # rather than /mcp/. Paired with NOT stripping /db-auth on
-            # the mcp-cbioportal-db-auth-ingress Ingress.
+            # Mount FastMCP at /db/mcp so this Deployment IS the public
+            # /db/mcp endpoint on mcp.cbioportal.org — public MCP is
+            # OAuth-gated by default. LibreChat continues to reach the
+            # header-trust `cbioagent-clickhouse-mcp` Deployment via the
+            # in-cluster ClusterIP Service (never touches the public
+            # ingress), so it's unaffected. Paired with NOT stripping
+            # /db on the mcp-cbioportal-db-ingress Ingress.
             - name: CLICKHOUSE_MCP_HTTP_PATH
-              value: "/db-auth/mcp"
+              value: "/db/mcp"
             # Trust X-Forwarded-* from any in-cluster source so uvicorn's
             # 307 trailing-slash redirect honors Traefik's
             # X-Forwarded-Proto: https. Same reasoning as the sibling

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -58,11 +58,31 @@ spec:
         - mcp.cbioportal.org
       secretName: mcp-cbio-cert
 ---
-# /db — separate Ingress so its own rate-limit middleware only applies
-# here. Same host + same TLS secret; Traefik merges Ingress rules per
-# host. The path is NOT stripped — FastMCP is configured (via the
-# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp) to mount
-# itself at /db/mcp so trailing-slash redirects build correct URLs.
+# /db — the public MCP entry point on mcp.cbioportal.org, now
+# Google-OAuth-gated by pointing at cbioagent-clickhouse-mcp-auth
+# (was cbioagent-clickhouse-mcp). LibreChat is unaffected: it dials
+# the unauthenticated `cbioagent-clickhouse-mcp` Deployment directly
+# over the in-cluster ClusterIP Service and never touches this Ingress.
+#
+# The /db path is NOT stripped — FastMCP is configured (via the
+# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp-auth)
+# to mount itself at /db/mcp so trailing-slash redirects and internal
+# routing build correct URLs.
+#
+# Also carries the root-level OAuth-plane routes that FastMCP's
+# GoogleProvider registers at the base_url ORIGIN (not under the MCP
+# mount path). Enumerated against a probe FastMCP+GoogleProvider
+# instance:
+#   /.well-known/oauth-authorization-server (AS metadata)
+#   /.well-known/oauth-protected-resource/... (resource metadata; suffix depends on mount path)
+#   /authorize     (auth code request)
+#   /token         (token exchange)
+#   /register      (Dynamic Client Registration for MCP clients)
+#   /consent       (host consent screen)
+#   /auth/callback (Google -> us callback; MUST match the URI
+#                  registered in Google Cloud Console for this client)
+# These paths are otherwise unused on mcp.cbioportal.org — no other
+# service on this host consumes them today.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -81,56 +101,9 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: cbioagent-clickhouse-mcp
-                port:
-                  number: 80
-  tls:
-    - hosts:
-        - mcp.cbioportal.org
-      secretName: mcp-cbio-cert
----
-# /db-auth — Google-OAuth-protected variant of /db, backed by
-# cbioagent-clickhouse-mcp-auth. Same host + same TLS secret. The
-# path is NOT stripped — FastMCP is configured (via the
-# CLICKHOUSE_MCP_HTTP_PATH env var on cbioagent-clickhouse-mcp-auth)
-# to mount itself at /db-auth/mcp so trailing-slash redirects and the
-# GoogleProvider callback URL (/db-auth/auth/callback) build correctly.
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: mcp-cbioportal-db-auth-ingress
-  annotations:
-    kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.middlewares: default-ratelimit-db@kubernetescrd
-  labels:
-    app.kubernetes.io/instance: cbioagent
-spec:
-  rules:
-    - host: mcp.cbioportal.org
-      http:
-        paths:
-          - path: /db-auth
-            pathType: Prefix
-            backend:
-              service:
                 name: cbioagent-clickhouse-mcp-auth
                 port:
                   number: 80
-          # FastMCP's GoogleProvider registers all OAuth endpoints at
-          # the base_url ORIGIN, not under the MCP mount path — so the
-          # OAuth-plane routes below all live at root and need Ingress
-          # to forward them into the same Deployment. Enumerated
-          # against a probe FastMCP+GoogleProvider instance:
-          #   /.well-known/oauth-authorization-server (AS metadata)
-          #   /.well-known/oauth-protected-resource/... (resource metadata; suffix depends on mount path)
-          #   /authorize     (auth code request)
-          #   /token         (token exchange)
-          #   /register      (Dynamic Client Registration for MCP clients)
-          #   /consent       (host consent screen)
-          #   /auth/callback (Google -> us callback; MUST match the URI
-          #                  registered in Google Cloud Console for this client)
-          # These paths are otherwise unused on mcp.cbioportal.org — no
-          # other service on this host consumes them today.
           - path: /.well-known/oauth-authorization-server
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary

The public MCP entry point on `mcp.cbioportal.org` is Google-OAuth protected going forward. Direct MCP connectors (Claude Desktop, Claude Code, claude.ai) must complete a Google login before any tool call — no more anonymous public access to the DB MCP.

**LibreChat is unaffected.** It dials the unauthenticated `cbioagent-clickhouse-mcp` Deployment via the in-cluster ClusterIP Service (`http://cbioagent-clickhouse-mcp:80/db/mcp/`) and never touches the public ingress. That header-trust deployment stays exactly as-is.

## Changes

- **`cbioagent-clickhouse-mcp-auth.yaml`** — flip `CLICKHOUSE_MCP_HTTP_PATH` from `/db-auth/mcp` → `/db/mcp` so FastMCP mounts under the sub-path the public ingress now routes.
- **`mcp-ingress.yaml`** — repoint `mcp-cbioportal-db-ingress` `/db` backend from `cbioagent-clickhouse-mcp` → `cbioagent-clickhouse-mcp-auth`, fold the OAuth-plane root routes (`.well-known/oauth-*`, `/authorize`, `/token`, `/register`, `/consent`, `/auth/callback`) into that same Ingress, and delete `mcp-cbioportal-db-auth-ingress` (redundant once consolidated).

No `portal-configuration` change needed: `CBIOPORTAL_MCP_GOOGLE_BASE_URL` is already the origin (mount-path independent), and the Google Console redirect URI is registered at `/auth/callback` (root), unaffected by the mount-path move.

## Migration friction

- Direct-connector clients currently at `https://mcp.cbioportal.org/db/mcp` **anonymously** will get 401 on their next request and re-auth via DCR + Google login. If a bookmark/doc was handed out with an implicit-anonymous expectation, flag those users.
- Clients on the beta `/db-auth/mcp` URL (currently only us) will 404 after the merge and need to switch to `/db/mcp`.
- **Resource-metadata URL** changes from `/.well-known/oauth-protected-resource/db-auth/mcp` → `/.well-known/oauth-protected-resource/db/mcp`. Cached-metadata clients self-heal on their next 401 via WWW-Authenticate.

## Test plan

- [ ] Argo sync → Reloader/Keel rolls `cbioagent-clickhouse-mcp-auth` on the env change.
- [ ] `curl -sD- -o /dev/null https://mcp.cbioportal.org/db/mcp/` → 401 with `WWW-Authenticate: Bearer resource_metadata=".../db/mcp"`.
- [ ] `curl -s https://mcp.cbioportal.org/.well-known/oauth-authorization-server` → 200 OAuth AS metadata (unchanged).
- [ ] `curl -s https://mcp.cbioportal.org/.well-known/oauth-protected-resource/db/mcp` → 200 (new path; old `/db-auth/mcp` path → 404, expected).
- [ ] Claude Desktop / Copilot at `https://mcp.cbioportal.org/db/mcp/` → Google login → tool calls succeed.
- [ ] Datadog `service:cbioportal-mcp-auth` spans still carry `enduser.id` + `enduser.email`.
- [ ] LibreChat regression check: agent still lists studies / runs queries against the ClusterIP-served `cbioagent-clickhouse-mcp` Deployment. (Should be unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj