### PR TITLE
cbioagent-mcp-auth: track cbioportal/mcp:latest, same as sibling

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/cbioagent-clickhouse-mcp-auth.yaml
@@ -33,15 +33,17 @@ spec:
     spec:
       containers:
         - name: cbioagent-clickhouse-mcp
-          # Google OAuth variant of the DB MCP — cbioportal-mcp#107
-          # (feat/mcp-google-oauth branch). All the same SQL tools +
-          # study guides as the main MCP; adds FastMCP's GoogleProvider
-          # so direct MCP connectors (Claude Desktop, Claude Code,
-          # claude.ai) authenticate via Google before any tool call.
-          # Deliberately kept as its own Deployment: the internal
-          # `cbioagent-clickhouse-mcp` LibreChat talks to stays
-          # unauthenticated so we don't disturb existing traffic.
-          image: cbioportal/mcp:mcp-google-oauth
+          # Same image as the sibling `cbioagent-clickhouse-mcp`
+          # (LibreChat-facing) Deployment. The OAuth code from
+          # cbioportal-mcp#107 is inert unless CBIOPORTAL_MCP_GOOGLE_*
+          # env vars are set — this Deployment sets them (via the
+          # cbioportal-mcp-google-oauth Secret) and gets Google-OAuth
+          # auth; the sibling doesn't and stays header-trust. Tracking
+          # `:latest` (built from `main` on cbioportal/cbioportal-mcp)
+          # keeps both Deployments in lockstep on the same binary;
+          # Keel rolls both when the digest changes. Swap to a semver
+          # tag if we want prod pinning.
+          image: cbioportal/mcp:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8000


### PR DESCRIPTION
## Summary

Point the auth Deployment at `cbioportal/mcp:latest` so it runs the exact same binary as the header-trust `cbioagent-clickhouse-mcp` Deployment. Both now pull main-built images; the **only** difference between the two Deployments is the OAuth env vars (sourced from the `cbioportal-mcp-google-oauth` Secret), which activate FastMCP's `GoogleProvider` on the auth one.

Was `:mcp-google-oauth` (the feature branch tag we iterated on before cbioportal-mcp#107 merged into `main`). That branch tag hasn't been re-pushed since 2026-08-14 16:52 UTC; #107 merged at 19:46, so `main` (and `:latest`) already carries the same OAuth code plus the two follow-up commits we added (email/profile scopes + `enduser.email` span attribute).

Both Deployments already Keel-track their tag digest and will roll in lockstep on future `main` pushes.

## Follow-up (later)

Swap `:latest` → a semver tag (`0.2.0` or similar) once we cut a release from `main`. Would remove the "any main push auto-rolls prod" behavior in favor of explicit pin bumps.

## Test plan

- [ ] Argo sync → Keel/rollout picks up the new tag. Pod rolls to `:latest` digest.
- [ ] `curl -sD- -o /dev/null https://mcp.cbioportal.org/db/mcp/` → still 401 with OAuth WWW-Authenticate (auth still working).
- [ ] Existing OAuth session continues to work (Claude Desktop / Copilot on `mcp.cbioportal.org/db/mcp/`).
- [ ] `pup traces search --query 'service:cbioportal-mcp-auth' --from 5m` shows spans with `enduser.email` after a test call (regression check on the span-attribute fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj