### PR TITLE
cbioagent: friendly redirects for browser clicks on the MCP URLs

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/mcp-ingress.yaml
@@ -8,6 +8,24 @@ spec:
     prefixes:
       - /navigator
 ---
+# 302 to the MCP setup docs. Applied to:
+#   - the bare-hostname root landing (mcp-cbioportal-root-redirect-ingress)
+#   - browser GETs to /db/mcp and /db-mcp-apps/mcp (via the
+#     mcp-cbioportal-browser-redirect-route IngressRoute below)
+# so a human who lands on the endpoint URL sees setup instructions
+# instead of a raw 401 JSON body. Non-permanent (302) so we can move
+# the docs URL later without stale-cache pain.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-mcp-docs
+  namespace: default
+spec:
+  redirectRegex:
+    regex: ^.*$
+    replacement: https://docs.cbioportal.org/ai-integrations/mcp/
+    permanent: false
+---
 # Rate-limit the public database MCP path. Unlike /navigator (which only
 # mints URLs), /db lets clients run arbitrary SELECTs against ClickHouse —
 # cap per-IP throughput so a single client (or scraper) can't DOS the
@@ -188,3 +206,91 @@ spec:
     - hosts:
         - mcp.cbioportal.org
       secretName: mcp-cbio-cert
+---
+# / on mcp.cbioportal.org — bare-hostname visits get 302'd to the MCP
+# setup docs instead of the current hard 404. `pathType: Exact` scopes
+# this to just `/`; the /db, /db-mcp-apps, /navigator, and OAuth-plane
+# paths remain served by their own Ingresses above. Backend is a
+# placeholder — the redirect middleware short-circuits the request.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-cbioportal-root-redirect-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-to-mcp-docs@kubernetescrd
+  labels:
+    app.kubernetes.io/instance: cbioagent
+spec:
+  rules:
+    - host: mcp.cbioportal.org
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: cbioagent-clickhouse-mcp-auth
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - mcp.cbioportal.org
+      secretName: mcp-cbio-cert
+---
+# Browser GETs to /db/mcp and /db-mcp-apps/mcp → 302 to docs. Uses a
+# Traefik IngressRoute (not a plain Ingress) because we need to match
+# on Method + User-Agent regex simultaneously, which the standard
+# Ingress spec doesn't express. Higher `priority` than any standard
+# Ingress rule so this route wins for matching requests.
+#
+# Detection: `HeaderRegexp("User-Agent", "Mozilla")` catches every
+# real browser (Chrome, Firefox, Safari, Edge — they all send
+# "Mozilla/5.0 (...)"). MCP clients don't: Anthropic/ClaudeAI,
+# Anthropic/Toolbox, github-copilot-developer, python-httpx, curl,
+# WhatsApp scraper, etc. all send non-Mozilla UAs and pass through
+# to the normal MCP path. `!HeaderRegexp("User-Agent", "(?i)(headless|kprofile-pipeline)")`
+# mirrors the sibling cbioportal-www-ingressroute pattern, excluding
+# our own headless testing traffic.
+#
+# GET-only: MCP Streamable HTTP uses GET for the SSE upgrade
+# (`Accept: text/event-stream`) — but MCP clients still send
+# non-Mozilla UAs there, so the UA check is sufficient to avoid
+# breaking SSE. POSTs (MCP RPC) are never intercepted.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: mcp-cbioportal-browser-redirect-route
+  namespace: default
+  labels:
+    app.kubernetes.io/instance: cbioagent
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: >-
+        Host(`mcp.cbioportal.org`) && PathPrefix(`/db/mcp`) && Method(`GET`) &&
+        HeaderRegexp(`User-Agent`, `Mozilla`) &&
+        !HeaderRegexp(`User-Agent`, `(?i)(headless|kprofile-pipeline)`)
+      kind: Rule
+      priority: 100
+      middlewares:
+        - name: redirect-to-mcp-docs
+          namespace: default
+      services:
+        - name: cbioagent-clickhouse-mcp-auth
+          port: 80
+    - match: >-
+        Host(`mcp.cbioportal.org`) && PathPrefix(`/db-mcp-apps/mcp`) && Method(`GET`) &&
+        HeaderRegexp(`User-Agent`, `Mozilla`) &&
+        !HeaderRegexp(`User-Agent`, `(?i)(headless|kprofile-pipeline)`)
+      kind: Rule
+      priority: 100
+      middlewares:
+        - name: redirect-to-mcp-docs
+          namespace: default
+      services:
+        - name: cbioagent-clickhouse-mcp-apps
+          port: 80
+  tls:
+    secretName: mcp-cbio-cert


### PR DESCRIPTION
## Problem

A human who clicks on `https://mcp.cbioportal.org/db/mcp/` (from docs, a link in Slack/WhatsApp, wherever) sees a raw 401 JSON body with a scary `WWW-Authenticate` header. Zero human affordance. Datadog shows several such bounces per day (`Mozilla/*` user agents, `HTTP 401` on `service:cbioportal-mcp-auth` — 3 in the 24h before this PR, 6 total the day before). The bare hostname `mcp.cbioportal.org/` hard-404s. Both quietly lose people who might have been about to try the endpoint.

## Fix

Two Traefik-level redirects to the existing MCP setup docs page (`docs.cbioportal.org/ai-integrations/mcp/`, verified live), no cbioportal-mcp code change:

- **`redirect-to-mcp-docs`** — Middleware, 302 to the docs page.
- **`mcp-cbioportal-root-redirect-ingress`** — standard Ingress on `path: /` `pathType: Exact` for the subdomain root. Backend is a placeholder; the middleware short-circuits before the request ever reaches a pod.
- **`mcp-cbioportal-browser-redirect-route`** — Traefik IngressRoute matching `PathPrefix(/db/mcp)` or `PathPrefix(/db-mcp-apps/mcp)` + `Method(GET)` + `HeaderRegexp(User-Agent, "Mozilla")`, `priority: 100` so it wins over the standard Ingresses for matching requests. IngressRoute (not plain Ingress) because method+UA regex isn't expressible in the standard Ingress spec.

Mirrors the User-Agent pattern already in production on `cbioportal-www-ingressroute` for `www.cbioportal.org`, including the `headless|kprofile-pipeline` exclusion so our own e2e traffic isn't mis-redirected.

## Why this is safe for MCP clients

| Traffic | UA starts with `Mozilla`? | Method | Intercepted? |
|---|---|---|---|
| MCP RPC (Claude Desktop, claude.ai, Copilot, python-httpx, curl) | No | POST | Never — POST isn't matched |
| MCP SSE upgrade (same clients) | No | GET | Never — UA check filters them out |
| OAuth flow (`/authorize`, `/token`, `/register`, `/consent`, `/auth/callback`, `/.well-known/oauth-*`) | Browser (yes) OR script (no) | GET | Never — these paths aren't in the redirect route |
| Browser click on `/db/mcp` | Yes | GET | **Yes → 302 to docs** |
| Bare `mcp.cbioportal.org/` in browser | Yes | GET | **Yes → 302 to docs** (root Ingress) |
| WhatsApp / Slack link-preview scrapers | No (`WhatsApp/2.2631.102`, etc.) | GET | No — falls through to 401 (fine) |

Google's OAuth consent flow requires browsers on `/authorize` etc. — those routes intentionally stay untouched (they live on `mcp-cbioportal-db-ingress`, above in the file).

## Test plan

- [ ] Argo sync → Middleware + IngressRoute + new Ingress reconcile.
- [ ] `curl -sI https://mcp.cbioportal.org/` → `302 Location: https://docs.cbioportal.org/ai-integrations/mcp/` (was 404).
- [ ] `curl -sI -H "User-Agent: Mozilla/5.0" https://mcp.cbioportal.org/db/mcp/` → `302` (was 307→401 JSON).
- [ ] `curl -sI -H "User-Agent: Mozilla/5.0" https://mcp.cbioportal.org/db-mcp-apps/mcp` → `302`.
- [ ] `curl -sD- -o /dev/null -X POST https://mcp.cbioportal.org/db/mcp -H "Content-Type: application/json" -d '{...init...}'` → still `401` with WWW-Authenticate (MCP path preserved).
- [ ] Real MCP client (Claude Desktop / claude.ai connector) still completes OAuth and lists tools end-to-end.
- [ ] `curl -sI https://mcp.cbioportal.org/authorize?client_id=...` → still `302` to Google (OAuth path preserved).
- [ ] LibreChat regression: chat.cbioportal.org still functions — irrelevant to this change (LibreChat uses ClusterIP, doesn't hit this ingress) but worth a smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj