### PR TITLE
cbioagent (203): drop trailing slash from LibreChat MCP URL

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cbioagent/librechat-config.yaml
@@ -110,8 +110,14 @@ data:
     mcpServers:
       cbioportal-database:
         type: streamable-http
-        # Trailing slash avoids FastMCP's 307 that LibreChat v0.8.7+ blocks as SSRF.
-        url: http://cbioagent-clickhouse-mcp:80/db/mcp/
+        # No trailing slash — the FastMCP 3.3.1 in cbioportal/mcp:latest
+        # (from cbioportal-mcp#107) mounts /db/mcp WITHOUT trailing slash
+        # as canonical. Requests to /db/mcp/ get a 307 back to /db/mcp,
+        # which LibreChat v0.8.7 fails to follow across the ClusterIP
+        # hop — pod log shows a wall of 307 -> 406 -> 404 retries and
+        # the tool call ultimately fails. Same fix as MSK-side (see
+        # portal-configuration#52).
+        url: http://cbioagent-clickhouse-mcp:80/db/mcp
         headers:
           x-user-id: "{{LIBRECHAT_USER_ID}}"
           x-user-email: "{{LIBRECHAT_USER_EMAIL}}"


### PR DESCRIPTION
## Symptom

Public chat.cbioportal.org LibreChat tool calls have been failing since 2026-08-16. Pod log on 203's `cbioagent-clickhouse-mcp` shows a wall of `POST /db/mcp/` → 307, then `POST /db/mcp` → 406, then `GET /.well-known/oauth-protected-resource*` → 404 retries. Datadog `service:cbioportal-mcp resource_name:mcp.tool/*` shows **0 spans in the last 2 days** despite GA reporting 19 users on chat yesterday (Aug 17) — users are chatting, MCP tool calls aren't landing.

## Root cause

`cbioportal/mcp:latest` bundles FastMCP 3.3.1 (from cbioportal-mcp#107 upgrading `fastmcp 2.10.6 → 2.13.3`), which mounts `/db/mcp` **without** a trailing slash as canonical. Requests to `/db/mcp/` get a 307 redirect back to `/db/mcp`. LibreChat v0.8.7's SSRF hardening blocks or mishandles the ClusterIP-to-ClusterIP redirect; LibreChat never reaches a working session, tool calls fail silently.

Same bug as MSK — fixed there in [portal-configuration#52](https://github.com/knowledgesystems/portal-configuration/pull/52) yesterday. I mis-diagnosed 203 as "tolerating" the 307 based on stale traffic numbers; the traffic I was seeing was from before the FastMCP upgrade digest rolled the pod.

## Verified from inside the cluster

```
POST http://cbioagent-clickhouse-mcp/db/mcp/   →  307 Location: /db/mcp
POST http://cbioagent-clickhouse-mcp/db/mcp    →  200 OK, mcp-session-id issued
```

## Test plan

- [ ] Argo sync → Reloader rolls `cbioagent-librechat` on the ConfigMap change.
- [ ] chat.cbioportal.org: send a study question, verify a `list_studies` or `run_select_query` tool call succeeds inline.
- [ ] `pup traces search --query 'service:cbioportal-mcp resource_name:mcp.tool/*' --from 15m` shows fresh spans (was 0 for 2 days).
- [ ] `kubectl logs deploy/cbioagent-clickhouse-mcp` stops showing the 307/406/404 loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj