### PR TITLE
[codex] use canonical beta host for WSI tile routes

### DIFF
--- a/.github/scripts/smoke_wsi_triage.sh
+++ b/.github/scripts/smoke_wsi_triage.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_url="${CBIOPORTAL_WSI_URL:-https://triage-beta.cbioportal.aws.mskcc.org/wsi}"
-origin="${CBIOPORTAL_WSI_ORIGIN:-https://triage-beta.cbioportal.aws.mskcc.org}"
+base_url="${CBIOPORTAL_WSI_URL:-https://beta.cbioportal.mskcc.org/wsi}"
+origin="${CBIOPORTAL_WSI_ORIGIN:-https://beta.cbioportal.mskcc.org}"
 source_url="s3://example.invalid/slide.svs"
 tile_path="${base_url%/}/tiles/zxy/0/0/0"
 

--- a/.github/workflows/smoke-wsi-triage.yml
+++ b/.github/workflows/smoke-wsi-triage.yml
@@ -6,12 +6,12 @@ on:
       url:
         description: Base URL including /wsi
         required: true
-        default: https://triage-beta.cbioportal.aws.mskcc.org/wsi
+        default: https://beta.cbioportal.mskcc.org/wsi
         type: string
       origin:
         description: Browser origin used for the CORS preflight
         required: true
-        default: https://triage-beta.cbioportal.aws.mskcc.org
+        default: https://beta.cbioportal.mskcc.org
         type: string
 
 permissions:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: triage-beta.cbioportal.aws.mskcc.org
+    - host: beta.cbioportal.mskcc.org
       http:
         paths:
           - path: /wsi/tiles


### PR DESCRIPTION
## Summary

- use the canonical `beta.cbioportal.mskcc.org` host for the tile-server WSI ingress
- align the manual smoke workflow and script defaults with that host
- preserve the existing WSI paths and routing behavior

This is a follow-up to merged PR #507. The original PR merged before the canonical beta-host correction was pushed.

## Validation

- YAML parsing passed for the workflow and Ingress
- `bash -n .github/scripts/smoke_wsi_triage.sh` passed
- `git diff --check` passed