### PR TITLE
Deploy cBioPortal backend PR 12216 to beta

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
@@ -251,7 +251,7 @@ spec:
           envFrom:
             - secretRef:
                 name: cbioportal-msk-beta-green
-          image: cbioportal/cbioportal-dev:491f20c0ce64b948b5f30e262a0cf926159f16f9-web-shenandoah
+          image: cbioportal/cbioportal-dev:f9dbb2273472bb42cc9d5d4f8ef0f8a624633f2a-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20


### PR DESCRIPTION
Updates the active beta green cBioPortal deployment to the CI-published backend image from cBioPortal PR #12216.

Image:
cbioportal/cbioportal-dev:f9dbb2273472bb42cc9d5d4f8ef0f8a624633f2a-web-shenandoah

The tile-server deployment is unchanged. Frontend PR #5608 has a successful Netlify preview and should be loaded in the beta browser with the cBioPortal frontend preview override after the backend rollout.