### PR TITLE
Configure beta WSI tile server URL

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -215,6 +215,7 @@ spec:
             - --wsi.access-token-audience=cbioportal-wsi
             - --wsi.access-token-ttl-seconds=300
             - --wsi.local-auth-bypass=false
+            - --msk.wsi.tile_server.url=https://beta.cbioportal.mskcc.org/wsi
             - --enable_study_tags=false
             - --sample_view.url=https://cbioportal.mskcc.org/patient?studyId=STUDY_ID&sampleId=SAMPLE_ID
             - --patient_view.url=https://cbioportal.mskcc.org/patient?studyId=STUDY_ID&caseId=CASE_ID

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
@@ -215,6 +215,7 @@ spec:
             - --wsi.access-token-audience=cbioportal-wsi
             - --wsi.access-token-ttl-seconds=300
             - --wsi.local-auth-bypass=false
+            - --msk.wsi.tile_server.url=https://beta.cbioportal.mskcc.org/wsi
             - --enable_study_tags=false
             - --sample_view.url=https://cbioportal.mskcc.org/patient?studyId=STUDY_ID&sampleId=SAMPLE_ID
             - --patient_view.url=https://cbioportal.mskcc.org/patient?studyId=STUDY_ID&caseId=CASE_ID


### PR DESCRIPTION
Adds the runtime WSI tile-server URL to both beta blue and beta green cBioPortal deployments.

- Sets `msk.wsi.tile_server.url=https://beta.cbioportal.mskcc.org/wsi`
- Enables the beta Pathology Slides tab
- No production manifests changed
- This PR contains only the two beta deployment manifest changes

Validated both YAML files and `git diff --check`.