### PR TITLE
Use ClickHouse as beta primary datasource

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -115,11 +115,11 @@ spec:
             - --db.user=$(DB_USER)
             - --db.password=$(DB_PASSWORD)
             - --db.suppress_schema_version_mismatch_errors=true
-            - --spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+            - --spring.datasource.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver
             - --spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
-            - --spring.datasource.url=$(DB_CONNECTION_STRING)
-            - --spring.datasource.username=$(DB_USER)
-            - --spring.datasource.password=$(DB_PASSWORD)
+            - --spring.datasource.url=$(DB_CLICKHOUSE_CONNECTION_STRING)
+            - --spring.datasource.username=$(DB_CLICKHOUSE_USER)
+            - --spring.datasource.password=$(DB_CLICKHOUSE_PASSWORD)
             - --tomcat.catalina.scope=runtime
             - --show.transcript_dropdown=true
             - --show.civic=$(SHOW_CIVIC)

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
@@ -115,11 +115,11 @@ spec:
             - --db.user=$(DB_USER)
             - --db.password=$(DB_PASSWORD)
             - --db.suppress_schema_version_mismatch_errors=true
-            - --spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+            - --spring.datasource.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver
             - --spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
-            - --spring.datasource.url=$(DB_CONNECTION_STRING)
-            - --spring.datasource.username=$(DB_USER)
-            - --spring.datasource.password=$(DB_PASSWORD)
+            - --spring.datasource.url=$(DB_CLICKHOUSE_CONNECTION_STRING)
+            - --spring.datasource.username=$(DB_CLICKHOUSE_USER)
+            - --spring.datasource.password=$(DB_CLICKHOUSE_PASSWORD)
             - --tomcat.catalina.scope=runtime
             - --show.transcript_dropdown=true
             - --show.civic=$(SHOW_CIVIC)


### PR DESCRIPTION
The beta Deployment currently sets the primary `spring.datasource.*` properties from the legacy MySQL variables, while the WSI data and mappers require the migrated ClickHouse database.

This updates beta blue and green to use:
- `DB_CLICKHOUSE_CONNECTION_STRING`
- `DB_CLICKHOUSE_USER`
- `DB_CLICKHOUSE_PASSWORD`
- `com.clickhouse.jdbc.ClickHouseDriver`

The existing legacy ClickHouse flags and WSI configuration are unchanged. This is beta-only.

Validation: YAML parsing and `git diff --check` pass.