### PR TITLE
fix(beta): restart tile server after ConfigMap changes

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -20,6 +20,8 @@ spec:
       labels:
         app: slide-viewer-triage
       annotations:
+        # Restart the pod when the ConfigMap-backed CORS allowlist changes.
+        slide-viewer-config-revision: "2026-08-25-netlify-preview-cors"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:


### PR DESCRIPTION
The tile-server CORS ConfigMap was updated in portal-configuration PR #60, but envFrom ConfigMap changes do not restart an existing pod.

Add a beta tile-server pod-template revision annotation so Argo rolls the pod and loads the new CORS_ORIGINS value. This is beta tile-server only.