### PR TITLE
fix(beta): set tile-server CORS origin explicitly

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-25-netlify-preview-cors"
+        slide-viewer-config-revision: "2026-08-25-netlify-preview-cors-v2"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:
@@ -62,6 +62,10 @@ spec:
             - configMapRef:
                 name: slide-viewer-triage-config
           env:
+            # Keep beta preview CORS explicit on the workload. The ConfigMap
+            # remains the shared source of the other tile-server settings.
+            - name: CORS_ORIGINS
+              value: "https://beta.cbioportal.mskcc.org,https://deploy-preview-5608.preview.cbioportal.org"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The live beta tile server still rejects the Netlify deploy-preview origin with `Disallowed CORS origin` after the shared ConfigMap update and rollout annotation.

Set `CORS_ORIGINS` explicitly on the beta tile-server workload and bump the pod revision so the process receives the allowlist deterministically. This is beta-only; production remains unchanged.

Expected preflight origin:
`https://deploy-preview-5608.preview.cbioportal.org`