### PR TITLE
fix(beta): force portal CORS rollout

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -25,6 +25,8 @@ spec:
     metadata:
       annotations:
         admission.datadoghq.com/java-lib.version: v1.24.2
+        # Force the beta portal pod to reload the credentialed preview CORS setting.
+        portal-cors-revision: "2026-08-25-beta-preview-cors-v2"
       labels:
         admission.datadoghq.com/enabled: "true"
         run: eks-msk-beta-blue
@@ -111,7 +113,7 @@ spec:
             - --dbconnector=dbcp
             - --authenticate=saml_plus_basic
             - --authorization=false
-            - --security.cors.allowed-origins=https://deploy-preview-5608.preview.cbioportal.org
+            - --security.cors.allowed-origins=https://beta.cbioportal.mskcc.org,https://deploy-preview-5608.preview.cbioportal.org
             - --db.user=$(DB_USER)
             - --db.password=$(DB_PASSWORD)
             - --db.suppress_schema_version_mismatch_errors=true


### PR DESCRIPTION
The live beta portal still returns responses without `Access-Control-Allow-Origin` for the Netlify preview, even though the merged beta deployment manifest contains the preview origin.

This beta-only change:
- allows both the beta origin and the Netlify deploy-preview origin;
- bumps the pod-template revision so Argo must recreate the portal pod and load the merged backend/CORS settings.

Production manifests are unchanged.