### PR TITLE
fix(beta): reload tile server CORS config

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-25-netlify-preview-cors"
+        slide-viewer-config-revision: "2026-08-25-netlify-preview-cors-v2"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:


### PR DESCRIPTION
The merged portal-configuration change added the canonical Netlify preview origin to `CORS_ORIGINS`, but the tile-server deployment consumes that value through `envFrom` only at process startup. Bump the beta pod-template revision so Argo rolls the beta tile-server pod and loads the current ConfigMap allowlist.

This is beta tile-server only; production is unchanged.

Validation:
- `git diff --check`
- Before the rollout, live preflight for `https://deploy-preview-5608--cbioportalfrontend.netlify.app` still returned `400 Disallowed CORS origin` while the ConfigMap already contained the origin.