### PR TITLE
fix(beta): deploy API CORS fix

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -265,7 +265,7 @@ spec:
           envFrom:
             - secretRef:
                 name: cbioportal-msk-beta-blue
-          image: cbioportal/cbioportal-dev:99000102ef654ea10f41207d3a7c774eea7280db-web-shenandoah
+          image: cbioportal/cbioportal-dev:7212dce461fc50e25dd885ff85bca2b49feac09a-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20


### PR DESCRIPTION
Deploy the backend commit from cBioPortal PR #12216 that enables CORS on the highest-priority `/api/**` Spring Security chain.

The live beta API currently answers WSI preflight requests with `401` and no CORS headers. This beta-only image update makes the CORS filter handle valid preflights before authentication.

This PR must remain draft until Docker Hub publishes:
`cbioportal/cbioportal-dev:7212dce461fc50e25dd885ff85bca2b49feac09a-web-shenandoah`

Production is unchanged.