### PR TITLE
fix(beta): deploy rebased API CORS image

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -265,7 +265,7 @@ spec:
           envFrom:
             - secretRef:
                 name: cbioportal-msk-beta-blue
-          image: cbioportal/cbioportal-dev:7212dce461fc50e25dd885ff85bca2b49feac09a-web-shenandoah
+          image: cbioportal/cbioportal-dev:158998ef8a2c27abbbf38c3e29ccca43b1a123ed-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20


### PR DESCRIPTION
Update the beta portal image to the rebased cBioPortal PR #12216 commit. The previous beta deployment PR was merged with the obsolete pre-rebase tag.

New image:
`cbioportal/cbioportal-dev:158998ef8a2c27abbbf38c3e29ccca43b1a123ed-web-shenandoah`

Keep this draft until Docker Hub publishes the tag. Production is unchanged.