### PR TITLE
fix(beta): deploy authorization CORS image

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -265,7 +265,7 @@ spec:
           envFrom:
             - secretRef:
                 name: cbioportal-msk-beta-blue
-          image: cbioportal/cbioportal-dev:158998ef8a2c27abbbf38c3e29ccca43b1a123ed-web-shenandoah
+          image: cbioportal/cbioportal-dev:be75ad85306abeb6f49fca6e8fe5e7139725d6d4-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20


### PR DESCRIPTION
Deploy the updated backend image to MSK beta blue.

The backend image adds `Authorization` to the portal API CORS allowed-header list. The current beta image accepts the Netlify preview origin but rejects preflights requesting this header, which browsers report as `Invalid CORS request`.

- Backend PR: cBioPortal/cbioportal#12216
- Image: `cbioportal/cbioportal-dev:be75ad85306abeb6f49fca6e8fe5e7139725d6d4-web-shenandoah`
- Docker Hub manifest verified before opening this PR
- Scope: beta-blue image reference only; production deployments are unchanged

After Argo CD sync, verify a preflight containing `authorization,content-type,x-current-url` returns 200 and includes `authorization` in `Access-Control-Allow-Headers`.