### PR TITLE
fix(beta): allow Keycloak SAML callback origin

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -113,7 +113,7 @@ spec:
             - --dbconnector=dbcp
             - --authenticate=saml_plus_basic
             - --authorization=false
-            - --security.cors.allowed-origins=https://beta.cbioportal.mskcc.org,https://deploy-preview-5608.preview.cbioportal.org,https://deploy-preview-5608--cbioportalfrontend.netlify.app
+            - --security.cors.allowed-origins=https://beta.cbioportal.mskcc.org,https://keycloak.cbioportal.mskcc.org,https://deploy-preview-5608.preview.cbioportal.org,https://deploy-preview-5608--cbioportalfrontend.netlify.app
             - --db.user=$(DB_USER)
             - --db.password=$(DB_PASSWORD)
             - --db.suppress_schema_version_mismatch_errors=true


### PR DESCRIPTION
Add the trusted MSK Keycloak origin to the explicit beta-blue CORS allowlist.

After authentication, Keycloak POSTs the SAML response to `/login/saml2/sso/cbio-saml-idp` with `Origin: https://keycloak.cbioportal.mskcc.org`. Beta currently rejects that request with `403 Invalid CORS request` before SAML validation.

Verified current live behavior with a non-secret dummy SAML payload:

- WSI API preflights from both Netlify preview origins pass.
- SAML callback POST from the Keycloak origin returns `403 Invalid CORS request`.

Scope is beta-blue only; no production deployment manifest is changed. After merge and Argo CD sync, the same callback probe should proceed to SAML validation instead of returning the CORS error.