### PR TITLE
fix(beta): deploy SAML CORS bypass image

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -265,7 +265,7 @@ spec:
           envFrom:
             - secretRef:
                 name: cbioportal-msk-beta-blue
-          image: cbioportal/cbioportal-dev:be75ad85306abeb6f49fca6e8fe5e7139725d6d4-web-shenandoah
+          image: cbioportal/cbioportal-dev:9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20


### PR DESCRIPTION
Deploy the backend image that exempts only the SAML response endpoint (`/login/saml2/sso/**`) from CORS processing.

This fixes the authenticated browser regression without adding the unsafe opaque `null` origin to the global API allowlist. API and WSI CORS remain strict.

- Backend PR: cBioPortal/cbioportal#12216
- Backend commit: `9cd8302621df06d59c94f69915e70bec87036024`
- Image: `cbioportal/cbioportal-dev:9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah`
- Docker Hub manifest verified for amd64 and arm64
- Focused backend tests: 3 passed, 0 failed
- Scope: beta-blue image reference only

Required live verification after Argo CD sync:

1. A POST to `/login/saml2/sso/cbio-saml-idp` with `Origin: null` no longer returns `Invalid CORS request`.
2. Netlify API preflight still allows `authorization,content-type,x-current-url`.
3. Tile preflight still allows `authorization,x-wsi-source`.