### PR TITLE
fix(beta): deploy WSI header-source image

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -52,8 +52,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Release v0.1.0 is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:v0.1.0@sha256:6950a87cf8a8ed588a17bcd9f71b0155b4162cd9645bfe3f566c9bf6f0f08088
+          # Header-source fix c992bcc is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:75ee97458f5d65f24e4705ede2c01b3d48f0ce5f2199609c5dc12ad2e76f682e
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- update only the `slide-viewer-triage` image used on `beta.cbioportal.mskcc.org`
- pin tile-server commit `c992bcc` by immutable multi-architecture digest
- leave all production cBioPortal deployments unchanged

## Verification
- published image label matches `c992bcc`
- exact image rendered a header-only JPEG thumbnail locally
- exact image rendered a header-only SVS tile locally
- duplicate-key and routing-script validation passed
- tile-server PR checks and all 155 tests passed
