### PR TITLE
Raise beta tile cache miss limit to 600

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -62,6 +62,8 @@ spec:
             - configMapRef:
                 name: slide-viewer-triage-config
           env:
+            - name: CACHE_MISS_RATE_LIMIT_PER_MINUTE
+              value: "600"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Set CACHE_MISS_RATE_LIMIT_PER_MINUTE to 600 for the beta tile server. This is a beta-only deployment change; production manifests are unchanged.