### PR TITLE
Raise beta WSI cache-miss limit to 1200

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -63,7 +63,7 @@ spec:
                 name: slide-viewer-triage-config
           env:
             - name: CACHE_MISS_RATE_LIMIT_PER_MINUTE
-              value: "600"
+              value: "1200"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Raise the beta WSI tile-server cache-miss limit from 600 to 1,200 per capability subject per minute.
- Keep the NGINX ingress request and connection limits unchanged.

## Verification
- Kubernetes YAML parsed successfully and the environment variable is in the container env section.
- uv run pytest -q in cbioportal-tile-server: 166 passed.
