### PR TITLE
Point beta backend at frontend PR 5608

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -83,7 +83,7 @@ spec:
             - --com.sun.management.jmxremote.local.only=false
             - --java.rmi.server.hostname=localhost
             # /enable remote debug
-            - --frontend.url=https://frontend.cbioportal.org/
+            - --frontend.url=https://deploy-preview-5608--cbioportalfrontend.netlify.app/
             - --default_cross_cancer_study_session_id=5c8a7d55e4b046111fee2296
             - --quick_search.enabled=true
             - --default_cross_cancer_study_list=mskimpact


### PR DESCRIPTION
## Summary
- Point the active MSK beta backend at the cBioPortal frontend PR 5608 Netlify preview.
- Keep the corresponding cBioPortal PR 12216 backend image already configured on beta.

## Verification
- Parsed both Kubernetes YAML documents with PyYAML.
- Asserted the PR 5608 frontend URL and PR 12216 backend image.
- `git diff --check` passed.