### PR TITLE
Raise beta WSI cache-miss limit to 2400

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -63,7 +63,7 @@ spec:
                 name: slide-viewer-triage-config
           env:
             - name: CACHE_MISS_RATE_LIMIT_PER_MINUTE
-              value: "1200"
+              value: "2400"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Raise the beta WSI tile-server cache-miss limit from 1,200 to 2,400 per minute.
- Keep the existing WSI ingress and decode-concurrency protections unchanged.

## Validation
- Duplicate-key validation passed for the beta WSI manifests.
- Kubeconform passed: 4 valid resources, 0 invalid, 0 errors, 1 skipped due to a missing schema.
- The local authenticated WSI smoke test returned 20/20 HTTP 200 responses.

## Rollout
- Sync the beta WSI Argo application after review.
- Monitor 429/503 rates, image queue time, extraction latency, Redis memory, and pod memory during the canary.