### PR TITLE
deploy(tile-server): update beta slide viewer

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -52,8 +52,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Header-source fix c992bcc is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:75ee97458f5d65f24e4705ede2c01b3d48f0ce5f2199609c5dc12ad2e76f682e
+          # Main 374f564 is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:6f2d6a2316212dc7d03f6c68728b13a70f101a25d9bd08e89e982d6a78851677
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -64,6 +64,14 @@ spec:
           env:
             - name: CACHE_MISS_RATE_LIMIT_PER_MINUTE
               value: "2400"
+            - name: CACHE_MISS_LOCK_TTL_SECONDS
+              value: "120"
+            - name: CACHE_MISS_WAIT_TIMEOUT_SECONDS
+              value: "60"
+            - name: GUNICORN_TIMEOUT
+              value: "180"
+            - name: CORS_ORIGINS
+              value: "https://beta.cbioportal.mskcc.org,https://deploy-preview-5608.preview.cbioportal.org,https://deploy-preview-5608--cbioportalfrontend.netlify.app"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -6,19 +6,23 @@ source URL and short-lived capability from the backend.
 
 ## Development capacity controls
 
-- The deployment starts with two fixed replicas and two Gunicorn workers per
-  pod. Autoscaling and disruption budgets are intentionally omitted while the
+- The checked-in deployment runs one replica. Gunicorn worker count and the
+  remaining runtime settings come from the private ConfigMap/environment.
+  Autoscaling and disruption budgets are intentionally omitted while the
   service is in development.
-- The container has a 16 GiB memory limit. CPU, ephemeral-storage, and memory
-  requests are intentionally unset until load testing establishes realistic
+- The checked-in container manifest has no CPU, ephemeral-storage, or memory
+  request/limit. Add those only after load testing establishes realistic
   values.
 - Pods select and tolerate `workload=tile-viewer`. That node group is managed
   outside this repository and must exist before the Argo Application is synced.
 - `MAX_IMAGE_OPERATIONS=1` bounds blocking tile/thumbnail work per worker.
 - `CACHE_MISS_RATE_LIMIT_PER_MINUTE` is a shared Redis sliding-window limit
-  for extraction leaders only. Redis cache hits are not application-rate-
-  limited.
+  for extraction leaders per capability subject and source. Redis cache hits
+  are not application-rate-limited.
 - Redis locks coalesce identical cache misses across workers and replicas.
+- Cold-read guardrails use a renewable 120-second distributed lock lease, a
+  60-second follower wait, and a 180-second Gunicorn worker timeout. These values do
+  not increase worker, image-operation, or open-slide concurrency.
 - Ingress retains a 100 requests/second limit, burst multiplier 5, and a
   50-connection limit per client.
 


### PR DESCRIPTION
Updates the beta slide-viewer deployment only.

- Pins beta to tile-server main digest for merged commit 374f564.
- Keeps the bounded cache-miss controls and cold-load timeouts.
- Does not modify cBioPortal production deployments.
- Argo CD auto-sync is expected to apply the change after merge.