### PR TITLE
chore(slide-viewer): restart beta after config update

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-25-netlify-preview-cors-v2"
+        slide-viewer-config-revision: "2026-08-27-production-thumbnail-manifest"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:


### PR DESCRIPTION
Bumps the existing beta slide-viewer config revision annotation so the pod rolls after the production thumbnail manifest ConfigMap update.

This is beta slide-viewer only; no cBioPortal production deployment is changed.