### PR TITLE
cell-explorer: pin image to sha-d10d93e

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:0.6.0
+          image: ghcr.io/cbioportal/cell-explorer-py:sha-d10d93e
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:0.5.0
+          image: ghcr.io/cbioportal/cell-explorer-py:0.6.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Pins cell-explorer to `ghcr.io/cbioportal/cell-explorer-py:sha-d10d93e`, up from `0.5.0`.

## Why a SHA rather than a version tag

The backend's `release.yml` is currently broken — `python-semantic-release` fails with `type object 'Actor' has no attribute 'name_email_regex'`, an upstream GitPython incompatibility that persists on the action's latest release (v10.6.1) and cannot be worked around from a version pin, since it is a Dockerfile action that installs its own dependencies.

`ci.yml` builds and pushes on every merge to `main`, so `sha-d10d93e` exists, is built from `main`, and includes the frontend redesign. Tracked separately; this deploy does not wait on it.

`sha-d10d93e` is `main` at the time of writing, containing everything below.

## What ships

Two backend features, neither previously deployed — prod is on `0.5.0`, which predates both:

- Dataset store metadata harvested server-side (cell counts, gene counts, embedding keys) and served on `/api/datasets`, so the catalogue no longer probes every zarr store from the browser to render counts.
- Per-column facet values, letting the landing page filter the catalogue by tissue, cell type, assay and so on.

The image bundles the frontend, so this also carries the landing page redesign that consumes both.

## Deploying

**Migrations run automatically.** The entrypoint is `alembic upgrade head && exec uvicorn`, so the pod applies both pending migrations on boot. `replicas: 1`, so no concurrent-migration race. Wait for the pod to be healthy before continuing.

**A backfill is required once the pod is up.** Existing dataset rows have no harvested metadata until a refresh runs, so until then the catalogue reports no counts and no facets:

```bash
curl -s -X POST https://cell-explorer.cbioportal.org/api/admin/datasets/metadata/refresh \
  -H "Authorization: Bearer $ADMIN_API_KEY" -H 'Content-Type: application/json' \
  -d '{"only_stale": true}'
```

Re-run until `refreshed` comes back at or near zero. The sweep is sequential at roughly two seconds per dataset and can outlast the ingress idle timeout — the request returns 504 while the work continues and commits per dataset. `only_stale: true` skips what already succeeded, so re-running converges. Full notes in the backend repo's `DEPLOYMENT.md`.

Expect a small number of per-dataset errors; datasets whose store cannot be read are recorded as errors and do not fail the sweep.

## Rollback

Revert this commit and sync. Both migrations are additive — one new table, one new nullable column — so `0.5.0` runs unchanged against the migrated database.
