### PR TITLE
cell-explorer: pin image to sha-d0e05c0

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:sha-d10d93e
+          image: ghcr.io/cbioportal/cell-explorer-py:sha-d0e05c0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Frontend-only redeploy: pins cell-explorer to `ghcr.io/cbioportal/cell-explorer-py:sha-d0e05c0`, up from `sha-d10d93e`.

## What changes

One frontend fix — cBioPortal/cbioportal-cell-explorer#305, which stops a focus ring appearing when a filter is clicked in the facet sidebar.

No backend code changes, **no migrations**, no backfill needed. The image bundles the frontend, so shipping a frontend fix means a new image.

The backend content of `sha-d0e05c0` differs from `sha-d10d93e` by one CI workflow change only (cBioPortal/cell-explorer-py#193, adding a `workflow_dispatch` trigger so frontend-only rebuilds can be triggered without a backend commit).

## Deploying

Sync. Nothing else — the pod restarts onto the new image, Alembic finds no pending migrations, and the harvested metadata already in the database is untouched.

## Rollback

Revert this commit and sync; `sha-d10d93e` is unchanged and still available.
