### PR TITLE
chore(beta): add WSI cold-open capacity

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -143,7 +143,8 @@ jobs:
             argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/slide-viewer-triage.yaml \
             argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml \
             argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml \
-            argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/network-policy.yaml
+            argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/network-policy.yaml \
+            argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
 
       - name: Validate WSI manifests
         run: |
@@ -155,7 +156,8 @@ jobs:
             argocd/aws/666628074417/clusters/cbioportal-prod/apps/argocd/slide-viewer-triage.yaml \
             argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml \
             argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml \
-            argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/network-policy.yaml
+            argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/network-policy.yaml \
+            argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
 
       - name: Check WSI routing smoke script
         run: bash -n .github/scripts/smoke_wsi_triage.sh

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: slide-viewer-triage
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: slide-viewer-triage
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-27-16m-decode-policy"
+        slide-viewer-config-revision: "2026-08-27-cold-open-guardrails"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:
@@ -39,6 +39,13 @@ spec:
           key: workload
           operator: Equal
           value: tile-viewer
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: slide-viewer-triage
       terminationGracePeriodSeconds: 60
       imagePullSecrets:
         - name: dockerhub-creds
@@ -70,9 +77,9 @@ spec:
             - name: CACHE_MISS_LOCK_TTL_SECONDS
               value: "120"
             - name: CACHE_MISS_WAIT_TIMEOUT_SECONDS
-              value: "90"
+              value: "30"
             - name: GUNICORN_TIMEOUT
-              value: "180"
+              value: "60"
             - name: CORS_ORIGINS
               value: "https://beta.cbioportal.mskcc.org,https://deploy-preview-5608.preview.cbioportal.org,https://deploy-preview-5608--cbioportalfrontend.netlify.app"
             - name: AWS_ACCESS_KEY_ID

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -59,8 +59,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Main b16cc21 is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:39e5eeda8fbde984e28519b29816fff3b67a532eca4c903a8f63ab66cddbe79d
+          # Main 42f0ded is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:c49ef9b1b8a56ead982c100615d91c2af872f651632e7f777127c561b8da581e
           imagePullPolicy: Always
           resources:
             requests:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: "100"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
     nginx.ingress.kubernetes.io/limit-connections: "50"
+    # Keep a slide's cold-open cache and SlideCache affinity on one pod.
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$http_x_wsi_source"
 spec:
   ingressClassName: nginx
   rules:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: slide-viewer-triage
+  namespace: default
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: slide-viewer-triage

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -6,13 +6,12 @@ source URL and short-lived capability from the backend.
 
 ## Development capacity controls
 
-- The checked-in deployment runs one replica. Gunicorn worker count and the
+- The beta canary runs two replicas with a disruption budget that keeps one
+  pod available during voluntary maintenance. Gunicorn worker count and the
   remaining runtime settings come from the private ConfigMap/environment.
-  Autoscaling and disruption budgets are intentionally omitted while the
-  service is in development.
-- The checked-in container manifest has no CPU, ephemeral-storage, or memory
-  request/limit. Add those only after load testing establishes realistic
-  values.
+- The checked-in container manifest reserves 8Gi and caps memory at 16Gi per
+  pod. CPU and ephemeral-storage requests/limits remain unset until sustained
+  production load establishes realistic values.
 - Pods select and tolerate `workload=tile-viewer`. That node group is managed
   outside this repository and must exist before the Argo Application is synced.
 - `MAX_IMAGE_OPERATIONS=1` bounds blocking tile/thumbnail work per worker.
@@ -21,10 +20,13 @@ source URL and short-lived capability from the backend.
   are not application-rate-limited.
 - Redis locks coalesce identical cache misses across workers and replicas.
 - Cold-read guardrails use a renewable 120-second distributed lock lease, a
-  60-second follower wait, and a 180-second Gunicorn worker timeout. These values do
-  not increase worker, image-operation, or open-slide concurrency.
+  30-second follower wait, a 2-second image-operation queue bound, and a
+  60-second Gunicorn worker timeout. ECS slide opens use bounded client
+  connect/read timeouts and retries. These values do not increase worker,
+  image-operation, or open-slide concurrency.
 - Ingress retains a 100 requests/second limit, burst multiplier 5, and a
-  50-connection limit per client.
+  50-connection limit per client. Requests carrying `X-WSI-Source` are hashed
+  to keep a slide's cold-open cache on one pod.
 
 The Redis instance used by `REDIS_URL` must have bounded memory, an LRU/LFU
 eviction policy, and alerts for evictions, memory pressure, and unavailable


### PR DESCRIPTION
## Summary
- run two beta tile-server replicas with a PDB
- keep slide requests source-affine at ingress
- shorten stale request bounds and validate the new PDB
- document the beta cold-open guardrails

## Rollout
Pair with the tile-server image and portal-configuration PRs.