### PR TITLE
chore(beta): deploy thumbnail ECS fallback

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -59,8 +59,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Main 42f0ded is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:c49ef9b1b8a56ead982c100615d91c2af872f651632e7f777127c561b8da581e
+          # Main c9ab6fe is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:627d7057287828f1c3308f176606e37dd7b29ffee7890c3bc2fb93a0cf38cf04
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## Summary
- pin beta slide-viewer-triage to the published thumbnail-read fallback image
- beta deployment only; production routing and image remain unchanged

## Image
- `cbioportal/cbioportal-tile-server:main@sha256:627d7057287828f1c3308f176606e37dd7b29ffee7890c3bc2fb93a0cf38cf04`

## Validation
- tile-server PR #31 merged
- multi-architecture image publish succeeded
- tile-server test suite: 194 passed