### PR TITLE
chore(beta): restart WSI pods after config reconcile

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-27-cold-open-guardrails"
+        slide-viewer-config-revision: "2026-08-28-thumbnail-read"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:


### PR DESCRIPTION
## Summary
- bump the beta WSI deployment revision annotation
- restart pods after portal-configuration#64 reconciles the current ECS credentials/config

## Scope
- beta slide-viewer-triage only
- production routing and application deployments unchanged

Paired with portal-configuration#64 and cbioportal-tile-server#31.