### PR TITLE
deploy(beta): pin thumbnail retry tile image

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -59,8 +59,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Main c9ab6fe is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:627d7057287828f1c3308f176606e37dd7b29ffee7890c3bc2fb93a0cf38cf04
+          # Main 464f29e is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:6e8ae75a8f9db62c3f925ab592974e7d90e2c969a35370e881f1ba5c82d58528
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## Summary

- pin the beta slide-viewer deployment to the immutable multi-architecture image built from tile-server commit `464f29e`
- deploy transient-only thumbnail retry handling to beta
- leave production manifests unchanged

## Image

`cbioportal/cbioportal-tile-server:main@sha256:6e8ae75a8f9db62c3f925ab592974e7d90e2c969a35370e881f1ba5c82d58528`

## Validation

- tile-server main build, multi-architecture publish, and container smoke checks passed
- tile-server test suite: 201 passed
