### PR TITLE
chore(beta): reset WSI block cache

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-28-thumbnail-read"
+        slide-viewer-config-revision: "2026-08-28-cold-tile-cache-reset"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:


### PR DESCRIPTION
## Summary

- bump the beta slide-viewer-triage pod-template revision to force a rolling restart
- clear each pod's emptyDir /cache/slide-blocks cache after the cold high-resolution tile failures
- leave images, credentials, replicas, routing, and production application manifests unchanged

## Scope

- beta WSI tile server only: slide-viewer-triage in default
- Argo CD sync will roll the pods with maxUnavailable: 0

## Validation

- YAML parsed successfully (Deployment and Service documents)
- git diff --check passed
- change is one annotation value only

After merge and Argo sync, rerun the cold-tile benchmark for slides 690901 and 2910060.