### PR TITLE
deploy(beta): roll out WSI cache repair

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-28-cold-tile-cache-reset"
+        slide-viewer-config-revision: "2026-08-28-wsi-cache-repair"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:
@@ -59,8 +59,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Main 464f29e is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:6e8ae75a8f9db62c3f925ab592974e7d90e2c969a35370e881f1ba5c82d58528
+          # Main 8188881 is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:2a371191ea1ad169ca1514790b14ab98c71a704c2ff08d67ebc7eff6986a0abd
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## Summary
- pin beta slide-viewer-triage to the published tile-server multi-architecture image
- roll the beta pods with a new template revision

## Scope
- only argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
- no production WSI deployment or routing changes

## Image
- tile-server main commit 8188881
- digest sha256:2a371191ea1ad169ca1514790b14ab98c71a704c2ff08d67ebc7eff6986a0abd

Apply/sync the Argo CD beta application after merge.