### PR TITLE
deploy(beta): reload thumbnail retry settings

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
-        slide-viewer-config-revision: "2026-08-28-wsi-cache-repair"
+        slide-viewer-config-revision: "2026-08-28-wsi-cache-repair-config"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:


### PR DESCRIPTION
## Summary
- roll the beta slide-viewer-triage pods after portal-configuration PR #65
- ensure THUMBNAIL_FETCH_MAX_ATTEMPTS and THUMBNAIL_FETCH_RETRY_DELAY_SEC are loaded from the synced ConfigMap

## Scope
- beta slide-viewer-triage deployment manifest only
- no production deployment or routing changes