### PR TITLE
fix(beta): keep green on CORS-fixed portal image

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
@@ -25,6 +25,8 @@ spec:
     metadata:
       annotations:
         admission.datadoghq.com/java-lib.version: v1.24.2
+        # Keep both beta release colors on the credentialed preview CORS revision.
+        portal-cors-revision: "2026-08-25-beta-preview-cors-v3"
       labels:
         admission.datadoghq.com/enabled: "true"
         run: eks-msk-beta-green
@@ -261,7 +263,7 @@ spec:
           envFrom:
             - secretRef:
                 name: cbioportal-msk-beta-green
-          image: cbioportal/cbioportal-dev:f9dbb2273472bb42cc9d5d4f8ef0f8a624633f2a-web-shenandoah
+          image: cbioportal/cbioportal-dev:9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20


### PR DESCRIPTION
## Summary
- promote beta-green to the same verified cBioPortal image already configured for beta-blue
- add the matching portal CORS rollout revision to beta-green
- keep the active green routing and all production deployments unchanged

## Root cause
The automated August 31 blue/green import switched beta traffic to green, but green was still pinned to f9dbb227. The CORS-fixed 9cd830262 image was present only on blue, which had zero replicas.

## Validation
- parsed both beta blue and green Deployment/Service manifests as YAML
- confirmed both colors now use image 9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah
- confirmed both colors have identical CORS origins and rollout revision
- git diff --check passes