### PR TITLE
[codex] Reset beta WSI block cache

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         app: slide-viewer-triage
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
+        # Force a clean beta block cache after source-region tile failures.
+        slide-viewer-cache-revision: "2026-08-31-block-cache-reset"
         slide-viewer-config-revision: "2026-08-28-wsi-cache-repair-config"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}


### PR DESCRIPTION
## What changed

Force one rolling replacement of the beta `slide-viewer-triage` pod by adding a pod-template cache revision.

## Why

Beta returns deterministic HTTP 500 responses for a contiguous source-image band on slide `3020726`, while neighboring tiles return 200. The exact beta image and source return 200 locally with a fresh block cache, indicating stale or corrupted beta block-cache state rather than rate limiting.

The Deployment uses an `emptyDir` for `/cache/slide-blocks`, so replacing the pod clears that cache without changing the image, credentials, rate limit, portal blue/green deployments, or production services.

## Validation

- `git diff --check`
- YAML parsed successfully
- Exact beta image digest tested locally with a fresh cache
- Previously failing coordinates returned JPEG 200 locally
