### PR TITLE
cell-explorer: pin image to sha-d3d494c

### DIFF
--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -8,6 +8,11 @@ metadata:
   annotations:
     # Restart when the aws creds (refreshed on a schedule) or app secrets change.
     secret.reloader.stakater.com/reload: "k8s-aws-creds-manager,cell-explorer-secrets"
+    # Config is injected with envFrom, which Kubernetes reads only at container
+    # start — a ConfigMap edit alone changes nothing until something restarts
+    # the pod. Without this, a config change and an image bump applied in the
+    # wrong order leave both merged and neither in effect.
+    configmap.reloader.stakater.com/reload: "cell-explorer-config"
 spec:
   replicas: 1
   strategy:

--- a/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
+++ b/argocd/aws/203403084713/clusters/cbioportal-prod/apps/cell-explorer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: cell-explorer
-          image: ghcr.io/cbioportal/cell-explorer-py:sha-d0e05c0
+          image: ghcr.io/cbioportal/cell-explorer-py:sha-d3d494c
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
Pins cell-explorer to `ghcr.io/cbioportal/cell-explorer-py:sha-d3d494c`, up from `sha-d0e05c0`.

Built from backend `d3d494c` with frontend `8759a9d`.

## What changes

- **Google Analytics support.** The backend serves a measurement id on `/api/info`; the frontend loads the GA script only when one is present. Nothing is tracked until the id is also set in the ConfigMap — knowledgesystems/portal-configuration#66 does that, and can merge in any order relative to this.
- **A configuration reference** in the backend README covering all 29 settings, with a test that fails if a new setting goes undocumented.
- The regenerated API client corrects `obs_columns` on the catalogue response from `string[]` to `ObsColumnInfo[]`, stale since the facet work.

No migrations, no backfill. Harvested dataset metadata is untouched.

## Verifying after sync

```
curl -s https://cell-explorer.cbioportal.org/api/info
```

`git_sha` should read `d3d494c`, and `google_analytics_id` should carry the id once #66 has reconciled. GA4's Realtime report is the end-to-end check.

## Rollback

Revert this commit and sync; `sha-d0e05c0` is unchanged and still available.


## Also: restart on ConfigMap changes

The Reloader annotation covered secrets but not the ConfigMap, while config is injected with `envFrom` — which Kubernetes reads only at container start. A ConfigMap edit therefore changed nothing until some unrelated event restarted the pod.

That is a quiet failure mode: apply a config change and an image bump in the wrong order and you get both merged, everything reporting healthy, and neither in effect. Adding `configmap.reloader.stakater.com/reload` makes ConfigMap edits self-apply.

Reloader already runs in this cluster (`reloader-reloader`, 77d) and other apps here use the configmap variant; cell-explorer just never had it.

With this in place the ordering between this PR and knowledgesystems/portal-configuration#66 stops mattering — whichever lands second triggers the restart.
