### PR TITLE
deploy(beta): roll out WSI cache recovery

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   annotations:
     argocd.argoproj.io/tracking-id: cbioportal:apps/Deployment:default/eks-msk-beta-blue
+    # Reload the inactive color too, so a signing-key rotation cannot leave
+    # blue issuing capabilities with a stale shared secret.
+    secret.reloader.stakater.com/reload: "cbioportal-wsi-auth"
   labels:
     run: eks-msk-beta-blue
     tags.datadoghq.com/env: eks-msk-beta

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   annotations:
     argocd.argoproj.io/tracking-id: cbioportal:apps/Deployment:default/eks-msk-beta-green
+    # Keep both beta colors on the same WSI signing-key revision.
+    secret.reloader.stakater.com/reload: "cbioportal-wsi-auth"
   labels:
     run: eks-msk-beta-green
     tags.datadoghq.com/env: eks-msk-beta

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
         # Force a clean beta block cache after source-region tile failures.
-        slide-viewer-cache-revision: "2026-08-31-block-cache-reset"
+        slide-viewer-cache-revision: "2026-08-31-native-overview-cache-recovery"
         slide-viewer-config-revision: "2026-08-28-wsi-cache-repair-config"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
@@ -61,8 +61,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Main 8188881 is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:2a371191ea1ad169ca1514790b14ab98c71a704c2ff08d67ebc7eff6986a0abd
+          # Main 8843009 is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:216729fb295ed3e912b4f9905de59b2aabd8bca702f921f994f33b58d2fff822
           imagePullPolicy: Always
           resources:
             requests:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: default
   labels:
     app: slide-viewer-triage
+  annotations:
+    # Secret values supplied through envFrom/valueFrom are captured when a
+    # pod starts. Reloader makes portal-configuration Secret changes replace
+    # both beta tile-server pods automatically.
+    secret.reloader.stakater.com/reload: "slide-viewer-secrets,cbioportal-wsi-auth"
+    configmap.reloader.stakater.com/reload: "slide-viewer-triage-config"
 spec:
   replicas: 2
   selector:
@@ -61,8 +67,8 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Main 8843009 is pinned to its immutable multi-architecture digest.
-          image: cbioportal/cbioportal-tile-server:main@sha256:216729fb295ed3e912b4f9905de59b2aabd8bca702f921f994f33b58d2fff822
+          # Main 2266b1d is pinned to its immutable multi-architecture digest.
+          image: cbioportal/cbioportal-tile-server:main@sha256:cfc404f70253a047e760e55951afd5e6c6ebb68e192217356527a1b2db5732d9
           imagePullPolicy: Always
           resources:
             requests:
@@ -104,6 +110,12 @@ spec:
                 secretKeyRef:
                   name: cbioportal-wsi-auth
                   key: WSI_AUTH_SECRET
+            - name: WSI_AUTH_PREVIOUS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cbioportal-wsi-auth
+                  key: WSI_AUTH_PREVIOUS_SECRET
+                  optional: true
           volumeMounts:
             - name: slide-block-cache
               mountPath: /cache/slide-blocks


### PR DESCRIPTION
## Summary
- pin beta slide-viewer-triage to the published tile-server main image for commit `2266b1d`
- reload tile-server on WSI secret/config changes
- keep both beta blue and green cBioPortal deployments synchronized on WSI secret rotation
- accept an optional previous WSI signing secret during rotation

## Scope
Beta manifests only under account `666628074417`. No production application deployment is changed.

## Verification
- tile-server upstream PR #36 passed container smoke and security checks
- local tile-server suite: 224 passed
- image was published as a multi-architecture manifest by the upstream workflow
