### PR TITLE
fix(beta): use node network for ECS tile serving

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -34,6 +34,11 @@ spec:
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:
       automountServiceAccountToken: false
+      # ECS is reachable from the worker-node network but not from the pod
+      # CIDR in this beta VPC. Keep the tile reader on the node network until
+      # the CNI/TGW egress path is repaired.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Summary
- run the beta tile-server on the worker-node network
- use `ClusterFirstWithHostNet` DNS so the ECS endpoint remains resolvable

## Why
The beta tile-viewer pod CIDR cannot reach `pmindecs.mskcc.org:9020`, while the worker-node network can. The required thumbnail prewarm therefore prevented the new pods from starting. This is scoped to the beta slide-viewer-triage Deployment; no production manifest is changed.

## Verification
- from the tile-viewer node network: ECS endpoint responded with HTTP 403 (TCP path reachable)
- from the pod network: connection timed out
- Kubernetes manifest validation will run in CI
