### PR TITLE
Add GITHUB_REPO env var to agentic-cancer-gene-classification

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
@@ -63,6 +63,11 @@ spec:
               value: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
             - name: LOG_LEVEL
               value: "INFO"
+            # Repo curator feedback issues get filed against. GITHUB_TOKEN
+            # (the filing bot's PAT) is not app config, so it lives in the
+            # acgc Secret (envFrom below) instead of here.
+            - name: GITHUB_REPO
+              value: "oncokb/agentic-cancer-gene-classification"
             # oncokb-db-public-rds-admin supplies DB_URL/DB_USERNAME/DB_PASSWORD
             # (the shared RDS instance's admin credentials); the app parses
             # DB_URL directly. MYSQL_DATABASE isn't part of that secret since


### PR DESCRIPTION
## Summary
- Curator feedback in the ACGC web app now files a GitHub issue server-side via the GitHub Issues API instead of requiring the curator to submit a prefilled compose form themselves on github.com.
- This adds `GITHUB_REPO` (the target repo name, `oncokb/agentic-cancer-gene-classification`) as plain app config on the Deployment, matching the existing pattern for non-sensitive config like `ANTHROPIC_SDK_PROVIDER`/`LOG_LEVEL`.
- The actual credential, `ONCOKBDEV_PRIVATE_ACCESS_TOKEN` (a fine-grained PAT for a dedicated bot account, scoped to Issues: write on just this repo), is being added separately as a key in the `acgc` Secret in `portal-configuration`, consistent with how other real credentials (DB, Redis, AWS) are handled there rather than in this repo.
- App-side change: https://github.com/oncokb/agentic-cancer-gene-classification/pull/65

## Test plan
- [ ] After merge + Argo CD sync, confirm the pod picks up `GITHUB_REPO` (`kubectl exec ... env | grep GITHUB`).
- [ ] Once `ONCOKBDEV_PRIVATE_ACCESS_TOKEN` is also added via `portal-configuration`, submit feedback in the app and confirm a GitHub issue is filed against `oncokb/agentic-cancer-gene-classification`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V93KhcrMYbhDt6MXLRRavH