### PR TITLE
Wire ACGC to the shared oncokb-github secret

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
@@ -86,6 +86,8 @@ spec:
                 name: redis-cluster
             - secretRef:
                 name: acgc
+            - secretRef:
+                name: oncokb-github
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## Summary
- Curator feedback in ACGC now files a GitHub issue server-side via the GitHub API, authenticated with `ONCOKBDEV_PRIVATE_ACCESS_TOKEN` (see app-side change: oncokb/agentic-cancer-gene-classification#65).
- Rather than provisioning a new dedicated token/Secret, this reuses the existing `oncokb-github` Secret — already wired into `oncokb_core.yaml` and `oncokb_public.yaml` via the same `envFrom`/`secretRef` pattern — by adding it to ACGC's `envFrom` list alongside `oncokb-db-public-rds-admin`, `redis-cluster`, and `acgc`.
- Follow-up to #616, which added the (non-secret) `GITHUB_REPO` env var for this same feature.

## Test plan
- [ ] After merge + Argo CD sync, confirm the pod picks up `ONCOKBDEV_PRIVATE_ACCESS_TOKEN` from `oncokb-github` (`kubectl exec ... env | grep ONCOKBDEV`).
- [ ] Submit feedback in the ACGC app and confirm a GitHub issue is filed against `oncokb/agentic-cancer-gene-classification`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V93KhcrMYbhDt6MXLRRavH