### PR TITLE
Enable Datadog product metrics for agentic-cancer-gene-classification

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/agentic-cancer-gene-classification/oncokb_acgc.yaml
@@ -63,11 +63,21 @@ spec:
               value: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
             - name: LOG_LEVEL
               value: "INFO"
-            # Repo curator feedback issues get filed against. GITHUB_TOKEN
-            # (the filing bot's PAT) is not app config, so it lives in the
-            # acgc Secret (envFrom below) instead of here.
+            # Repo curator feedback issues get filed against.
+            # ONCOKBDEV_PRIVATE_ACCESS_TOKEN (the filing bot's PAT) is not app
+            # config, so it comes from the shared oncokb-github Secret
+            # (envFrom below) instead of here.
             - name: GITHUB_REPO
               value: "oncokb/agentic-cancer-gene-classification"
+            # DogStatsD product metrics (usage + cache hit-rate dashboards).
+            # DATADOG_STATSD_HOST/PORT are deliberately left unset — the app
+            # then falls through to DogStatsd's own DD_DOGSTATSD_URL env var
+            # detection, which resolves to the Unix socket the Datadog
+            # admission controller already injects for APM tracing above.
+            - name: DATADOG_METRICS_ENABLED
+              value: "true"
+            - name: DATADOG_METRICS_NAMESPACE
+              value: "acgc"
             # oncokb-db-public-rds-admin supplies DB_URL/DB_USERNAME/DB_PASSWORD
             # (the shared RDS instance's admin credentials); the app parses
             # DB_URL directly. MYSQL_DATABASE isn't part of that secret since


### PR DESCRIPTION
## Summary
- Turns on `DATADOG_METRICS_ENABLED`/`DATADOG_METRICS_NAMESPACE` so ACGC's usage and cache hit-rate metrics actually flow — see oncokb/agentic-cancer-gene-classification#71, which adds those metrics and fixes the DogStatsD client to work with this cluster's Unix-socket Datadog agent setup instead of a UDP host:port.
- `DATADOG_STATSD_HOST`/`PORT` are deliberately left unset — the app now falls through to DogStatsd's own `DD_DOGSTATSD_URL` env var detection, resolving to the same Unix socket already injected for APM tracing.
- Also fixes a stale comment referencing the old `GITHUB_TOKEN` name and the `acgc` Secret, from before #617 renamed it to `ONCOKBDEV_PRIVATE_ACCESS_TOKEN` and moved it to the shared `oncokb-github` Secret.

## Test plan
- [ ] After merge + Argo CD sync + pod restart, confirm `DATADOG_METRICS_ENABLED=true` is picked up (`kubectl exec ... env | grep DATADOG`).
- [ ] Confirm metrics like `acgc.pipeline.runs`, `acgc.genes.annotated`, `acgc.feedback.submitted` appear in Datadog Metrics Explorer after some traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V93KhcrMYbhDt6MXLRRavH