### PR TITLE
fix(iac): reconcile beta tile viewer capacity

### DIFF
--- a/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
@@ -272,8 +272,8 @@ locals {
     tile-viewer = {
       instance_types = ["r7g.large"]
       ami_type       = "BOTTLEROCKET_ARM_64"
-      desired_size   = 1
-      max_size       = 1
+      desired_size   = 2
+      max_size       = 2
       min_size       = 1
       taints = {
         dedicated = {


### PR DESCRIPTION
Reconcile the dedicated tile-viewer managed node group with the live beta deployment.

The deployment runs two 8Gi tile-server replicas; the live node group is already min=1, desired=2, max=2. This updates Terraform to prevent a future apply from reverting beta to one worker.

The unrelated local manifest changes are intentionally excluded.