### PR TITLE
perf(beta): scale WSI tile viewer capacity

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -8,11 +8,11 @@ metadata:
   annotations:
     # Secret values supplied through envFrom/valueFrom are captured when a
     # pod starts. Reloader makes portal-configuration Secret changes replace
-    # both beta tile-server pods automatically.
+    # all beta tile-server pods automatically.
     secret.reloader.stakater.com/reload: "slide-viewer-secrets,cbioportal-wsi-auth"
     configmap.reloader.stakater.com/reload: "slide-viewer-triage-config"
 spec:
-  replicas: 2
+  replicas: 4
   selector:
     matchLabels:
       app: slide-viewer-triage
@@ -29,7 +29,7 @@ spec:
         # Restart the pod when the ConfigMap-backed CORS allowlist changes.
         # Force a clean beta block cache after source-region tile failures.
         slide-viewer-cache-revision: "2026-08-31-native-overview-cache-recovery"
-        slide-viewer-config-revision: "2026-09-01-thumbnail-prewarm-key"
+        slide-viewer-config-revision: "2026-09-04-cold-open-capacity"
         ad.datadoghq.com/tile-server.checks: >-
           {"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics","namespace":"wsi_tile_server","metrics":["tile_server_.*"]}]}}
     spec:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: slide-viewer-triage
   namespace: default
 spec:
-  minAvailable: 1
+  minAvailable: 3
   selector:
     matchLabels:
       app: slide-viewer-triage

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -6,15 +6,18 @@ source URL and short-lived capability from the backend.
 
 ## Development capacity controls
 
-- The beta canary runs two replicas with a disruption budget that keeps one
-  pod available during voluntary maintenance. Gunicorn worker count and the
-  remaining runtime settings come from the private ConfigMap/environment.
+- The beta canary runs four replicas with a disruption budget that keeps
+  three pods available during voluntary maintenance. Gunicorn worker count
+  and the remaining runtime settings come from the private ConfigMap/
+  environment.
 - The checked-in container manifest reserves 8Gi and caps memory at 16Gi per
   pod. CPU and ephemeral-storage requests/limits remain unset until sustained
   production load establishes realistic values.
 - Pods select and tolerate `workload=tile-viewer`. That node group is managed
   outside this repository and must exist before the Argo Application is synced.
-- `MAX_IMAGE_OPERATIONS=1` bounds blocking tile/thumbnail work per worker.
+- `MAX_IMAGE_OPERATIONS=2` bounds blocking tile/thumbnail work per worker;
+  four replicas and two Gunicorn workers provide sixteen bounded image
+  operation slots across beta.
 - `CACHE_MISS_RATE_LIMIT_PER_MINUTE` is a shared Redis sliding-window limit
   for extraction leaders per capability subject and source. Redis cache hits
   are not application-rate-limited.

--- a/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
@@ -272,9 +272,9 @@ locals {
     tile-viewer = {
       instance_types = ["r7g.large"]
       ami_type       = "BOTTLEROCKET_ARM_64"
-      desired_size   = 2
-      max_size       = 2
-      min_size       = 1
+      desired_size   = 4
+      max_size       = 4
+      min_size       = 2
       taints = {
         dedicated = {
           key    = var.TAINT_KEY


### PR DESCRIPTION
## Summary
- scale the beta WSI tile viewer from 2 to 4 replicas
- reconcile the dedicated tile-viewer node group to 4 r7g.large nodes
- keep three pods available during voluntary disruption
- document the 16 bounded image-operation slots

The node group is dedicated to `workload=tile-viewer`; this does not change production application workloads.

Validated with YAML parsing, duplicate-key checks, and smoke-script syntax.