### PR TITLE
fix(beta): fit WSI rollout to dedicated node pool

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -19,8 +19,10 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      # The dedicated pool has one 8Gi pod per node. Roll one pod at a time
+      # so a four-replica rollout does not require a temporary fifth node.
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
Use maxSurge=0 and maxUnavailable=1 for the four-replica beta WSI deployment. The dedicated tile-viewer nodes are sized for one 8Gi pod each, so the previous surge strategy required an unavailable fifth node. The existing PDB keeps three pods available.