### PR TITLE
perf(beta): raise WSI client connection ceiling

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/ingress.yaml
@@ -12,7 +12,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/limit-rps: "100"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
-    nginx.ingress.kubernetes.io/limit-connections: "50"
+    # Allow approximately six browser connections for each of 50 concurrent
+    # users behind one NAT address. The tile server still bounds expensive
+    # image work independently with MAX_IMAGE_OPERATIONS.
+    nginx.ingress.kubernetes.io/limit-connections: "300"
     # Keep a slide's cold-open cache and SlideCache affinity on one pod.
     nginx.ingress.kubernetes.io/upstream-hash-by: "$http_x_wsi_source"
 spec:

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -28,7 +28,8 @@ source URL and short-lived capability from the backend.
   connect/read timeouts and retries. These values do not increase worker,
   image-operation, or open-slide concurrency.
 - Ingress retains a 100 requests/second limit, burst multiplier 5, and a
-  50-connection limit per client. Requests carrying `X-WSI-Source` are hashed
+  300-connection limit per client (six browser connections for 50 users behind
+  one NAT address). Requests carrying `X-WSI-Source` are hashed
   to keep a slide's cold-open cache on one pod.
 
 The Redis instance used by `REDIS_URL` must have bounded memory, an LRU/LFU


### PR DESCRIPTION
Raise the beta WSI ingress per-client connection ceiling from 50 to 300. A 50-user browser workload can create up to six concurrent pixel connections per client/NAT address. Expensive image work remains bounded by the tile-server operation semaphore and the dedicated four-node pool.

Validated with the repository WSI manifest checks.