### PR TITLE
chore(beta): reduce idle WSI capacity

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -12,7 +12,10 @@ metadata:
     secret.reloader.stakater.com/reload: "slide-viewer-secrets,cbioportal-wsi-auth"
     configmap.reloader.stakater.com/reload: "slide-viewer-triage-config"
 spec:
-  replicas: 4
+  # Observed beta peak is six concurrent users. Keep two warm replicas for
+  # cross-AZ availability; scale out manually to the four-node ceiling for
+  # an announced load event until workload autoscaling is added.
+  replicas: 2
   selector:
     matchLabels:
       app: slide-viewer-triage

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
@@ -4,7 +4,9 @@ metadata:
   name: slide-viewer-triage
   namespace: default
 spec:
-  minAvailable: 3
+  # Two replicas are the steady-state floor; preserve one available pod
+  # during voluntary disruption or node maintenance.
+  minAvailable: 1
   selector:
     matchLabels:
       app: slide-viewer-triage

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -6,17 +6,19 @@ source URL and short-lived capability from the backend.
 
 ## Development capacity controls
 
-- The beta canary runs four replicas with a disruption budget that keeps
-  three pods available during voluntary maintenance. Gunicorn worker count
-  and the remaining runtime settings come from the private ConfigMap/
-  environment.
+- Beta runs two warm replicas with a disruption budget that keeps one pod
+  available during voluntary maintenance. The dedicated node group keeps a
+  two-node steady-state floor and a four-node ceiling; scale to the ceiling
+  manually for an announced load event until workload autoscaling is added.
+  Gunicorn worker count and the remaining runtime settings come from the
+  private ConfigMap/environment.
 - The checked-in container manifest reserves 8Gi and caps memory at 16Gi per
   pod. CPU and ephemeral-storage requests/limits remain unset until sustained
   production load establishes realistic values.
 - Pods select and tolerate `workload=tile-viewer`. That node group is managed
   outside this repository and must exist before the Argo Application is synced.
 - `MAX_IMAGE_OPERATIONS=2` bounds blocking tile/thumbnail work per worker;
-  four replicas and two Gunicorn workers provide sixteen bounded image
+  two replicas and two Gunicorn workers provide eight bounded image
   operation slots across beta.
 - `CACHE_MISS_RATE_LIMIT_PER_MINUTE` is a shared Redis sliding-window limit
   for extraction leaders per capability subject and source. Redis cache hits

--- a/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
@@ -272,7 +272,7 @@ locals {
     tile-viewer = {
       instance_types = ["r7g.large"]
       ami_type       = "BOTTLEROCKET_ARM_64"
-      desired_size   = 4
+      desired_size   = 2
       max_size       = 4
       min_size       = 2
       taints = {


### PR DESCRIPTION
Reduces beta WSI steady-state capacity based on observed peak concurrency of six users.

Changes:
- Set slide-viewer-triage to 2 replicas.
- Set PDB minAvailable to 1.
- Set tile-viewer nodegroup to min 2 / desired 2 / max 4.
- Document the two-node steady state and manual burst scale-up.

Scope: beta WSI tile viewer only; no production portal routing or deployment changes.