### PR TITLE
chore(beta): run WSI viewer on one node

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -12,10 +12,10 @@ metadata:
     secret.reloader.stakater.com/reload: "slide-viewer-secrets,cbioportal-wsi-auth"
     configmap.reloader.stakater.com/reload: "slide-viewer-triage-config"
 spec:
-  # Observed beta peak is six concurrent users. Keep two warm replicas for
-  # cross-AZ availability; scale out manually to the four-node ceiling for
-  # an announced load event until workload autoscaling is added.
-  replicas: 2
+  # Beta accepts node/pod downtime. Keep one warm replica for the observed
+  # low concurrency; scale out manually to the four-node ceiling for an
+  # announced load event until workload autoscaling is added.
+  replicas: 1
   selector:
     matchLabels:
       app: slide-viewer-triage

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/pdb.yaml
@@ -4,9 +4,9 @@ metadata:
   name: slide-viewer-triage
   namespace: default
 spec:
-  # Two replicas are the steady-state floor; preserve one available pod
-  # during voluntary disruption or node maintenance.
-  minAvailable: 1
+  # Beta intentionally permits its only pod to be voluntarily disrupted;
+  # availability is not a production requirement for this environment.
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: slide-viewer-triage

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -6,10 +6,12 @@ source URL and short-lived capability from the backend.
 
 ## Development capacity controls
 
-- Beta runs two warm replicas with a disruption budget that keeps one pod
-  available during voluntary maintenance. The dedicated node group keeps a
-  two-node steady-state floor and a four-node ceiling; scale to the ceiling
-  manually for an announced load event until workload autoscaling is added.
+- Beta runs one warm replica and accepts node/pod downtime. The dedicated
+  node group keeps a one-node steady-state floor and a four-node ceiling;
+  scale to the ceiling manually for an announced load event until workload
+  autoscaling is added.
+- The beta disruption budget allows the single pod to be voluntarily
+  disrupted; production should use a separate multi-replica policy.
   Gunicorn worker count and the remaining runtime settings come from the
   private ConfigMap/environment.
 - The checked-in container manifest reserves 8Gi and caps memory at 16Gi per
@@ -18,8 +20,8 @@ source URL and short-lived capability from the backend.
 - Pods select and tolerate `workload=tile-viewer`. That node group is managed
   outside this repository and must exist before the Argo Application is synced.
 - `MAX_IMAGE_OPERATIONS=2` bounds blocking tile/thumbnail work per worker;
-  two replicas and two Gunicorn workers provide eight bounded image
-  operation slots across beta.
+  one replica and two Gunicorn workers provide four bounded image operation
+  slots across beta.
 - `CACHE_MISS_RATE_LIMIT_PER_MINUTE` is a shared Redis sliding-window limit
   for extraction leaders per capability subject and source. Redis cache hits
   are not application-rate-limited.

--- a/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
+++ b/iac/aws/666628074417/clusters/cbioportal-prod/eks/main.tf
@@ -272,9 +272,9 @@ locals {
     tile-viewer = {
       instance_types = ["r7g.large"]
       ami_type       = "BOTTLEROCKET_ARM_64"
-      desired_size   = 2
+      desired_size   = 1
       max_size       = 4
-      min_size       = 2
+      min_size       = 1
       taints = {
         dedicated = {
           key    = var.TAINT_KEY


### PR DESCRIPTION
Reduces beta WSI steady-state capacity for the observed peak of six concurrent users.

Changes:
- Set slide-viewer-triage to one replica.
- Permit the single beta pod to be voluntarily disrupted.
- Set the tile-viewer nodegroup to min 1 / desired 1 / max 4.
- Update operations documentation.

Scope: beta WSI tile viewer only; no production portal routing or deployment changes. Three-user concurrent benchmark will run after reconciliation.