### PR TITLE
Let the Datadog Agent tolerate the acgc (agcg) node's taint

### DIFF
--- a/argocd/aws/175678591974/clusters/oncokb-research/apps/datadog/values.yaml
+++ b/argocd/aws/175678591974/clusters/oncokb-research/apps/datadog/values.yaml
@@ -43,6 +43,17 @@ agents:
       operator: Equal
       value: test
       effect: NoSchedule
+    # Named agcg, not acgc, matching the eks_managed_node_groups map key in
+    # iac/aws/175678591974/clusters/oncokb-research/eks/main.tf (kept as agcg
+    # there specifically so Terraform doesn't destroy/recreate the live node
+    # group) — this is the dedicated node for
+    # apps/agentic-cancer-gene-classification. Without this, the DaemonSet
+    # can't schedule onto that node at all, so neither APM traces nor
+    # DogStatsD product metrics from that app ever reach an agent.
+    - key: workload
+      operator: Equal
+      value: agcg
+      effect: NoSchedule
 clusterAgent:
   admissionController:
     enabled: true


### PR DESCRIPTION
## Summary
- The `agentic-cancer-gene-classification` app runs on a dedicated node group tainted `workload=agcg:NoSchedule` (kept as `agcg` rather than `acgc` in `iac/aws/175678591974/clusters/oncokb-research/eks/main.tf` specifically so Terraform doesn't destroy/recreate the live node group — see that file's comment).
- The `datadog` Agent DaemonSet's toleration list (`argocd/aws/175678591974/clusters/oncokb-research/apps/datadog/values.yaml`) already tolerates every other dedicated workload taint (`main`, `curation`, `airflow`, `cronjob`, `redis-cl`, `beta`, `nonessential`, `ingress`, `test`) — `agcg` was the one missing.
- Net effect: no Datadog Agent pod could ever schedule onto that node, so the app's APM traces and DogStatsD product metrics (enabled in #618) had no local agent to reach, regardless of the app's own config being correct.

Found while investigating why acgc's usage/cache-hit-rate metrics weren't showing up on the Datadog dashboard despite real traffic, after confirming #618's env vars were live: the running pod logs `failed to send, dropping N traces ... Network error: client error (Connect)` on the APM socket, and `kubectl get pods -A -o wide` showed no `datadog-*` DaemonSet pod scheduled on the node the app pod landed on.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.../datadog/values.yaml'))"` — parses cleanly, 10 tolerations (9 existing + the new `agcg` one).
- This repo's `validate-configs.yml` CI only lints YAML under `apps/cbioagent`, so it doesn't cover this file — validated the YAML manually instead.

## Rollout
After merge + sync, the Datadog DaemonSet should schedule a new agent pod onto the `agcg` node automatically (no action needed there). Worth then confirming the `agentic-cancer-gene-classification` pod's APM trace-socket error clears and metrics start appearing on its dashboard.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>