### PR TITLE
deploy(beta): enable PR 12216 WSI serving policy

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -266,6 +266,8 @@ spec:
                   name: cbioportal-wsi-auth
                   key: WSI_AUTH_SECRET
           envFrom:
+            - configMapRef:
+                name: wsi-serving-policy
             - secretRef:
                 name: cbioportal-msk-beta-blue
           image: cbioportal/cbioportal-dev:9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -270,7 +270,7 @@ spec:
                 name: wsi-serving-policy
             - secretRef:
                 name: cbioportal-msk-beta-blue
-          image: cbioportal/cbioportal-dev:9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah
+          image: cbioportal/cbioportal-dev:e21471b8a0a3febb7296c0d454b2cfa346a741ff-web-shenandoah
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 20

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-green-deployment-service.yaml
@@ -263,6 +263,8 @@ spec:
                   name: cbioportal-wsi-auth
                   key: WSI_AUTH_SECRET
           envFrom:
+            - configMapRef:
+                name: wsi-serving-policy
             - secretRef:
                 name: cbioportal-msk-beta-green
           image: cbioportal/cbioportal-dev:9cd8302621df06d59c94f69915e70bec87036024-web-shenandoah

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/deployment.yaml
@@ -90,6 +90,8 @@ spec:
               protocol: TCP
           envFrom:
             - configMapRef:
+                name: wsi-serving-policy
+            - configMapRef:
                 name: slide-viewer-triage-config
           env:
             - name: CACHE_MISS_LOCK_TTL_SECONDS

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/wsi-serving-policy.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/wsi-serving-policy.yaml
@@ -4,6 +4,5 @@ metadata:
   name: wsi-serving-policy
   namespace: default
 data:
-  WSI_ALLOWED_SOURCE_PREFIXES: >-
-    s3://mskmind-bkt/reef-slides/,s3://mskmind-bkt/reef-slides-reprocess-staging/,s3://mskmind-bkt/reef-slides-reprocess-backup/,s3://mskmind-bkt/reef-slides-reprocess-backups/,s3://mskmind-bkt/reef-slides-remediated/,s3://ocra/,s3://pathology/CRC_21-167/,s3://pathology/BR_20-226/,s3://pathology/NB_16-1335/,s3://pathology/LUNG_18-193/,s3://pathology/CART_19-373/,s3://pathology/BR_16-512/,s3://pathology/MYE_16-1591/,s3://pathology/LUNG_18-193-dev/,s3://pathology/LUNG-HNE/,s3://pathology/LUNG_18-193-dev-2/,s3://pathology/TCGA/,s3://pathology/TCGA-BRCA/,s3://pathology/TCGA-COAD/,s3://pathology/crc-genetic-ancestry/,s3://pathology/TOX_19-114/,s3://pathology/SPECTRUM/,s3://pathology/sample/
+  WSI_ALLOWED_SOURCE_PREFIXES: s3://pathology/,s3://mskmind-bkt/,s3://ocra/
   WSI_ALLOWED_THUMBNAIL_PREFIXES: s3://mskmind-bkt/wsi-thumbnails/

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/wsi-serving-policy.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/slide-viewer-triage/wsi-serving-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wsi-serving-policy
+  namespace: default
+data:
+  WSI_ALLOWED_SOURCE_PREFIXES: >-
+    s3://mskmind-bkt/reef-slides/,s3://mskmind-bkt/reef-slides-reprocess-staging/,s3://mskmind-bkt/reef-slides-reprocess-backup/,s3://mskmind-bkt/reef-slides-reprocess-backups/,s3://mskmind-bkt/reef-slides-remediated/,s3://ocra/,s3://pathology/CRC_21-167/,s3://pathology/BR_20-226/,s3://pathology/NB_16-1335/,s3://pathology/LUNG_18-193/,s3://pathology/CART_19-373/,s3://pathology/BR_16-512/,s3://pathology/MYE_16-1591/,s3://pathology/LUNG_18-193-dev/,s3://pathology/LUNG-HNE/,s3://pathology/LUNG_18-193-dev-2/,s3://pathology/TCGA/,s3://pathology/TCGA-BRCA/,s3://pathology/TCGA-COAD/,s3://pathology/crc-genetic-ancestry/,s3://pathology/TOX_19-114/,s3://pathology/SPECTRUM/,s3://pathology/sample/
+  WSI_ALLOWED_THUMBNAIL_PREFIXES: s3://mskmind-bkt/wsi-thumbnails/

--- a/docs/apps/slide-viewer.md
+++ b/docs/apps/slide-viewer.md
@@ -60,10 +60,14 @@ time, 429/503 rates, pod restarts, memory, and block-cache volume usage.
 
 ## Release procedure
 
-1. Build and publish the tile-server image, then replace the tag in the
-   deployment with the exact immutable `image@sha256:<digest>` reference
-   before promotion. The deployment is not promotion-ready while it contains
-   only a tag.
+The `wsi-serving-policy` ConfigMap is the shared non-secret artifact policy for
+MSK beta and the shared tile service. The portal importer and tile service must
+receive the same values; a release that only allows one source root is not a
+complete WSI release.
+
+1. Build and publish the backend and tile-server images, then replace their
+   tags in the deployment with exact immutable `image@sha256:<digest>`
+   references before promotion.
 2. Build the green ClickHouse database with the WSI access projection and
    import the complete `meta_wsi.txt`/`data_wsi.txt` snapshots.
 3. Verify WSI row counts, `can_serve_tiles`, projection materialization, and


### PR DESCRIPTION
## Summary

- Add the shared beta WSI serving policy for `s3://pathology/`, `s3://mskmind-bkt/`, and `s3://ocra/`.
- Inject that policy into both beta portal colors and the shared tile server.
- Pin beta-blue to the immutable cBioPortal PR #12216 image `e21471b8a0a3febb7296c0d454b2cfa346a741ff-web-shenandoah`.
- Keep ingress on green until beta data/health validation is complete; blue/green promotion is a separate change.

## Validation

- YAML syntax and Kubernetes manifest validation are run by CI.
- This branch is based on the current upstream `master`.
