### PR TITLE
deploy(beta): promote hydrated blue portal

### DIFF
--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/cbioportal-eks-msk-beta-blue-deployment-service.yaml
@@ -14,7 +14,7 @@ metadata:
   name: eks-msk-beta-blue
 spec:
   progressDeadlineSeconds: 600
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/eks-msk-ingress.yaml
+++ b/argocd/aws/666628074417/clusters/cbioportal-prod/apps/cbioportal/eks-msk-ingress.yaml
@@ -105,7 +105,7 @@ spec:
         paths:
           - backend:
               service:
-                name: eks-msk-beta-green
+                name: eks-msk-beta-blue
                 port:
                   number: 80
             path: /
@@ -115,7 +115,7 @@ spec:
         paths:
           - backend:
               service:
-                name: eks-msk-beta-green
+                name: eks-msk-beta-blue
                 port:
                   number: 80
             path: /


### PR DESCRIPTION
Promote beta.cbioportal.mskcc.org and beta.cbioportal.aws.mskcc.org from green to the hydrated blue portal.

- scale eks-msk-beta-blue to 1 replica
- switch both beta ingress backends to eks-msk-beta-blue
- retain green deployment at 1 replica for rollback

Pre-cutover evidence:
- cbioportal_msk_beta schema 3.1.0; WSI tables contain no release_id
- 27,556,410 WSI rows and placements
- 2,084,135 mskimpact WSI rows
- 9,403,110 pathology timeline events
- derived clinical, event, mutation, generic-assay data rebuilt with spill-safe joins
- beta API and WSI health endpoints return 200

Argo auto-sync should apply this after CI passes.